### PR TITLE
docs(collection): clarify `stateChanges()` return

### DIFF
--- a/docs/firestore/collections.md
+++ b/docs/firestore/collections.md
@@ -176,7 +176,7 @@ export class AppComponent {
 
 ### `stateChanges()`
 
-**What is it?** - Returns an Observable of the most recent changes as a `DocumentChangeAction[]`. On initial subscription, all relevant documents are returned as `'added'` `DocumentChangeAction` objects. At the moment, there is no way to *just* subscribe to document changes and not also return all relevant documents on initial subscription.
+**What is it?** - Returns an Observable of the most recent changes as a `DocumentChangeAction[]`. On initial subscription, all relevant documents are returned as `'added'` `DocumentChangeAction` objects. At the moment, there is no way to *just* subscribe to document changes and not also return all relevant documents on initial subscription (though one way to "fake" this functionality is to add an `updatedAt` timestamp to your documents and then subscribe to `stateChanges()` where `updatedAt > now`).
 
 **Why would you use it?** - The above methods return a synchronized array sorted in query order. `stateChanges()` emits changes as they occur rather than syncing the query order. This works well for ngrx integrations as you can build your own data structure in your reducer methods.
 

--- a/docs/firestore/collections.md
+++ b/docs/firestore/collections.md
@@ -176,7 +176,7 @@ export class AppComponent {
 
 ### `stateChanges()`
 
-**What is it?** - Returns an Observable of the most recent changes as a `DocumentChangeAction[]`. 
+**What is it?** - Returns an Observable of the most recent changes as a `DocumentChangeAction[]`. On initial subscription, all relevant documents are returned as `'added'` `DocumentChangeAction` objects. At the moment, there is no way to *just* subscribe to document changes and not also return all relevant documents on initial subscription.
 
 **Why would you use it?** - The above methods return a synchronized array sorted in query order. `stateChanges()` emits changes as they occur rather than syncing the query order. This works well for ngrx integrations as you can build your own data structure in your reducer methods.
 


### PR DESCRIPTION
This PR updates the `Collection#stateChanges()` documentation to better describe it's behavior. I found the current description to be highly misleading, as

> Returns an Observable of the most recent changes as a DocumentChangeAction[]

Led me to believe that *only* document changes would be returned, and not the entire collection. I appear to not be alone in this interpretation ([see this S.O. post and the related (incorrect) answer](https://stackoverflow.com/q/54778296/5490505)).

Thanks!