### PR TITLE
fix: exception while running command ng deploy (#2088)

### DIFF
--- a/src/schematics/deploy/builder.ts
+++ b/src/schematics/deploy/builder.ts
@@ -29,7 +29,6 @@ export default createBuilder<any>(
     const project = workspace.getProject(context.target.project);
 
     const firebaseProject = getFirebaseProjectName(
-      workspace.root,
       context.target.project
     );
 
@@ -37,7 +36,7 @@ export default createBuilder<any>(
       await deploy(
         require("firebase-tools"),
         context,
-        join(workspace.root, project.root),
+        project.root,
         firebaseProject
       );
     } catch (e) {

--- a/src/schematics/utils.ts
+++ b/src/schematics/utils.ts
@@ -1,6 +1,5 @@
 import { readFileSync } from "fs";
 import { FirebaseRc, Project } from "./interfaces";
-import { join } from "path";
 
 export function listProjects() {
   const firebase = require('firebase-tools');
@@ -57,11 +56,10 @@ export const projectPrompt = (projects: Project[]) => {
 };
 
 export function getFirebaseProjectName(
-  projectRoot: string,
   target: string
 ): string | undefined {
   const { targets }: FirebaseRc = JSON.parse(
-    readFileSync(join(projectRoot, ".firebaserc"), "UTF-8")
+    readFileSync(".firebaserc", "UTF-8")
   );
   const projects = Object.keys(targets!);
   return projects.find(


### PR DESCRIPTION
### Checklist

   - Issue number for this PR: #2088(required)
   - Docs included?: (yes/no; required for all API/functional changes) 
   - Test units included?: (yes/no; required) 
   - In a clean directory, `yarn install`, `yarn test` run successfully? (yes/no; required)

### Description

When we execute `ng deploy` command, `workspace.root` gives the wrong path in the Windows environment, that's why it doesn't work in the Windows environment.
Using only `project root` In `getFirebaseProjectName` and `deploy`, will successfully allow `ng deploy` while executing it at project root in windows and linux environment.
fixes #2088
