### PR TITLE
fix(ci): Use node 10 to fix the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 sudo: false
 node_js:
-- 'lts/*'
+  - "10"
 
 addons:
   chrome: stable


### PR DESCRIPTION
Currently node version for travis is LTS, which switched from 10 to 12 recently, hence all builds are failing because of node-gyp.

![image](https://user-images.githubusercontent.com/216412/67620194-340d7200-f7d2-11e9-9134-e5b18f39a949.png)

My understanding is that updating to firebase 7 would eventually allow us to switch back to LTS, but short term this should fix the build. 

cc #2221
