### PR TITLE
fix(auth-router) Broken canActivate() helper logic

### DIFF
--- a/src/auth-guard/auth-guard.ts
+++ b/src/auth-guard/auth-guard.ts
@@ -24,8 +24,8 @@ export class AngularFireAuthGuard implements CanActivate {
 
 }
 
-export const canActivate = (pipe: AuthPipe|AuthPipeGenerator) => ({
-    canActivate: [ AngularFireAuthGuard ], data: { authGuardPipe: pipe.name === "" ? pipe : () => pipe}
+export const canActivate = (pipe: AuthPipe | AuthPipeGenerator) => ({
+  canActivate: [AngularFireAuthGuard], data: { authGuardPipe: pipe.name !== 'piped' ? pipe : () => pipe },
 });
 
 export const loggedIn: AuthPipe = map(user => !!user);


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: Fixes #2099
   - Docs included?: no
   - Test units included?: no
   - In a clean directory, `yarn install`, `yarn test` run successfully? yes

### Description

`canActivate()` has the ternary of `pipe.name === '' ? pipe : () => pipe` which seems to be intended to tell if the `pipe` is in either this format `() => pipe` or `pipe` format currently. If it in `pipe` format then the output of `pipe.name` seems to be `piped` however if it is  in `() => pipe` format the the result of `pipe.name` is actually the name of the function which appears to what has been overlooked with the original logic as `pipe.name` never seems to be an empty string.

Adjusting to `pipe.name !== 'piped' ? pipe : () => pipe` should fix this issue in all situations unless the name of the function is `piped` which would result in `authGuardPipe` being set to `() => () => pipe` which in my testing seems to behave has expected still activating the pipe however I am unsure of the exact ramifications of this.

I have only been playing with this for about an hour or two, so if there is something I am missing definitely let me know.
