### PR TITLE
fix(auth): use `onAuthStateChanged` for `authState`

### DIFF
--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -48,7 +48,7 @@ export class AngularFireAuth {
     });
 
     this.authState = new Observable<User | null>(subscriber => {
-      return zone.runOutsideAngular(() => this.auth.onIdTokenChanged(subscriber));
+      return zone.runOutsideAngular(() => this.auth.onAuthStateChanged(subscriber));
     }).pipe(keepUnstableUntilFirst);;
 
     this.user = new Observable<User | null>(subscriber => {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: #2307 (required)
   - Docs included?: no
   - Test units included?: no
   - In a clean directory, `yarn install`, `yarn test` run successfully? yes

### Description

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->
This fixes #2307 where `AngularFireAuth.authState` incorrectly uses `auth.onIdTokenChanged`.

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->

None