### PR TITLE
Removing the problematic share from the zone.js changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ matrix:
 branches:
   only:
     - master # otherwise pull requests get built twice
+    - v5
 
 install:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,38 +6,12 @@ node_js:
 addons:
   chrome: stable
 
-cache:
-  yarn: true
-  directories:
-    - node_modules
-    - "$HOME/.npm"
-    - "$HOME/.cache"
-
-env:
-  - CANARY=false
-  - CANARY=true
-
-matrix:
-  fast_finish: true
-  allow_failures:
-    - env: CANARY=true
-
 branches:
   only:
     - master # otherwise pull requests get built twice
     - v5
 
-install:
-  - |
-    if $CANARY; then
-      yarn upgrade && yarn add firebase@canary
-    else
-      if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then
-        yarn upgrade
-      else
-        yarn install --frozen-lockfile
-      fi
-    fi
+install: yarn install --frozen-lockfile
 
 script:
   - yarn build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+<a name="5.4.2"></a>
+## [5.4.2](https://github.com/angular/angularfire2/compare/5.4.1...5.4.2) (2020-02-06)
+
+
+### Bug Fixes
+
+* **core:** fixing a problem with hot/cold observables resulting in missed events ([#2315](https://github.com/angular/angularfire2/issues/2315)) ([6dd0409](https://github.com/angular/angularfire2/commit/6dd0409))
+
+
 <a name="5.4.1"></a>
 ## [5.4.1](https://github.com/angular/angularfire2/compare/5.4.0...5.4.1) (2020-02-05)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular/fire",
-  "version": "5.4.1",
+  "version": "5.4.2",
   "description": "The official library of Firebase and Angular.",
   "private": true,
   "scripts": {

--- a/src/core/angularfire2.ts
+++ b/src/core/angularfire2.ts
@@ -90,8 +90,9 @@ export function ɵkeepUnstableUntilFirstFactory(
       // Run the subscribe body outside of Angular (e.g. calling Firebase SDK to add a listener to a change event)
       subscribeOn(schedulers.outsideAngular),
       // Run operators inside the angular zone (e.g. side effects via tap())
-      observeOn(schedulers.insideAngular),
-      share()
+      observeOn(schedulers.insideAngular)
+      // This isn't working correctly #2309, #2314, #2312
+      // share()
     );
   }
 }


### PR DESCRIPTION
I believe this to be the root cause of #2309, #2314, #2312.

This came up in the review of #2243 but neither my test applications or the test suite caught that it would cause any issues. I merged into 5.x series because I figured `fromRef` was deep enough in the codebase and dropping a `share()` wasn't a big deal.

I'm planning to drop this in a patch.

Demonstrating the break fix/here https://stackblitz.com/edit/angular-7kb1uf?file=src%2Fapp%2Fapp.component.ts