### PR TITLE
fix: missing closing brace in docs

### DIFF
--- a/docs/auth/router-guards.md
+++ b/docs/auth/router-guards.md
@@ -39,7 +39,7 @@ const belongsToAccount = (next) => hasCustomClaim(`account-${next.params.id}`);
 export const routes: Routes = [
     { path: '',      component: AppComponent },
     { path: 'login', component: LoginComponent,        canActivate: [AngularFireAuthGuard], data: { authGuardPipe: redirectLoggedInToItems }},
-    { path: 'items', component: ItemListComponent,     canActivate: [AngularFireAuthGuard], data: { authGuardPipe: redirectUnauthorizedToLogin },
+    { path: 'items', component: ItemListComponent,     canActivate: [AngularFireAuthGuard], data: { authGuardPipe: redirectUnauthorizedToLogin }},
     { path: 'admin', component: AdminComponent,        canActivate: [AngularFireAuthGuard], data: { authGuardPipe: adminOnly }},
     { path: 'accounts/:id', component: AdminComponent, canActivate: [AngularFireAuthGuard], data: { authGuardPipe: belongsToAccount }}
 ];


### PR DESCRIPTION
Update to documentation.

Add missing closing brace in code example