### PR TITLE
QuerySnapshot returned in get function was not generic

### DIFF
--- a/src/firestore/collection/collection.ts
+++ b/src/firestore/collection/collection.ts
@@ -3,7 +3,7 @@ import { fromCollectionRef } from '../observable/fromRef';
 import { map, filter, scan, observeOn } from 'rxjs/operators';
 import { firestore } from 'firebase/app';
 
-import { DocumentChangeType, CollectionReference, Query, DocumentReference, DocumentData, DocumentChangeAction } from '../interfaces';
+import { DocumentChangeType, CollectionReference, Query, DocumentReference, DocumentData, DocumentChangeAction, QuerySnapshot } from '../interfaces';
 import { docChanges, sortedChanges } from './changes';
 import { AngularFirestoreDocument } from '../document/document';
 import { AngularFirestore } from '../firestore';
@@ -51,7 +51,7 @@ export class AngularFirestoreCollection<T=DocumentData> {
    */
   constructor(
     public readonly ref: CollectionReference,
-    private readonly query: Query,
+    private readonly query: Query<T>,
     private readonly afs: AngularFirestore) { }
 
   /**
@@ -127,7 +127,7 @@ export class AngularFirestoreCollection<T=DocumentData> {
    * @param options
    */
   get(options?: firestore.GetOptions): Observable<firestore.QuerySnapshot<T>> {
-    return from(this.query.get(options)).pipe(
+    return from<Promise<firestore.QuerySnapshot<T>>>(this.query.get(options)).pipe(
       observeOn(this.afs.schedulers.insideAngular),
     );
   }

--- a/src/firestore/collection/collection.ts
+++ b/src/firestore/collection/collection.ts
@@ -126,7 +126,7 @@ export class AngularFirestoreCollection<T=DocumentData> {
    * Retrieve the results of the query once.
    * @param options
    */
-  get(options?: firestore.GetOptions) {
+  get(options?: firestore.GetOptions): Observable<firestore.QuerySnapshot<T>> {
     return from(this.query.get(options)).pipe(
       observeOn(this.afs.schedulers.insideAngular),
     );

--- a/src/firestore/interfaces.ts
+++ b/src/firestore/interfaces.ts
@@ -54,9 +54,9 @@ export interface Reference<T> {
 
 // A convience type for making a query.
 // Example: const query = (ref) => ref.where('name', == 'david');
-export type QueryFn = (ref: CollectionReference) => Query;
+export type QueryFn = (ref: CollectionReference) => Query<DocumentData>;
 
-export type QueryGroupFn = (query: Query) => Query;
+export type QueryGroupFn = (query: Query<DocumentData>) => Query<DocumentData>;
 
 /**
  * A structure that provides an association between a reference
@@ -82,5 +82,5 @@ export type QueryGroupFn = (query: Query) => Query;
  */
 export interface AssociatedReference {
   ref: CollectionReference;
-  query: Query;
+  query: Query<DocumentData>;
 }

--- a/src/firestore/interfaces.ts
+++ b/src/firestore/interfaces.ts
@@ -8,7 +8,7 @@ export type PersistenceSettings = firestore.PersistenceSettings;
 export type DocumentChangeType = firestore.DocumentChangeType;
 export type SnapshotOptions = firestore.SnapshotOptions;
 export type FieldPath = firestore.FieldPath;
-export type Query = firestore.Query;
+export type Query<T> = firestore.Query<T>;
 
 export type SetOptions = firestore.SetOptions;
 export type DocumentData = firestore.DocumentData;


### PR DESCRIPTION
### Checklist

   - Issue number for this PR: #2438
   - Docs included?: no
   - Test units included?: no 
   - In a clean directory, `yarn install`, `yarn test` run successfully? yes

### Description

I've added a generic return type to the get() function in class AngularFirestoreCollection so developers receiving their own types using the QueryDocumentSnapshot.

### Code sample

let users: Array<{ username: string }>

this.fireStore.collection<{ username: string }>('users').get().subscribe(querySnapshot => {
users = querySnapshot.docs.map(doc => doc.data())
})

