### PR TITLE
Fixed typo in collections.md line 194

### DIFF
--- a/docs/firestore/collections.md
+++ b/docs/firestore/collections.md
@@ -191,7 +191,7 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 export interface AccountDeposit { description: string; amount: number; }
-export interface AccountDepoistId extends AccountDeposit { id: string; }
+export interface AccountDepositId extends AccountDeposit { id: string; }
 
 @Component({
   selector: 'app-root',


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: #2461 (required)
   - Docs included?: yes (yes/no; required for all API/functional changes) 
   - Test units included?: no (yes/no; required) 
   - In a clean directory, `yarn install`, `yarn test` run successfully? no (yes/no; required)

### Description

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

This pull request is to fix a documentation typo, on line 194 of ./docs/firestore/collections.md. The line is exporting an interface AccountDepositId but it is improperly named _AccountDepoistId_. This pull request fixes this typographical error.

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->

Current State:
```typescript
export interface AccountDepoistId extends AccountDeposit { id: string; }
```
State with Pull Request Merged:
```typescript
export interface AccountDepositId extends AccountDeposit { id: string; }
```
