### PR TITLE
Fix functions emulator origin url

### DIFF
--- a/docs/functions/functions.md
+++ b/docs/functions/functions.md
@@ -110,7 +110,7 @@ import { AngularFireFunctionsModule, ORIGIN } from '@angular/fire/functions';
   ],
   ...
   providers: [
-   { provide: ORIGIN, useValue: 'http://localhost:5005' }
+   { provide: ORIGIN, useValue: 'http://localhost:5001' }
   ]
 })
 export class AppModule {}


### PR DESCRIPTION
The default port in the firebase emulator for functions is 5001, not 5005

<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: #nnn (required)
   - Docs included?: (yes/no; required for all API/functional changes) 
   - Test units included?: (yes/no; required) 
   - In a clean directory, `yarn install`, `yarn test` run successfully? (yes/no; required)

### Description

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->
Documentation fix for emulated function
### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->

