### PR TITLE
fix(auth-guard):  Explicit return types

### DIFF
--- a/src/auth-guard/auth-guard.ts
+++ b/src/auth-guard/auth-guard.ts
@@ -64,6 +64,9 @@ export const isNotAnonymous: AuthPipe = map(user => !!user && !user.isAnonymous)
 export const idTokenResult = switchMap((user: User|null) => user ? user.getIdTokenResult() : of(null));
 export const emailVerified: AuthPipe = map(user => !!user && user.emailVerified);
 export const customClaims = pipe(idTokenResult, map(idTokenResult => idTokenResult ? idTokenResult.claims : []));
-export const hasCustomClaim = (claim: string) => pipe(customClaims, map(claims =>  claims.hasOwnProperty(claim)));
-export const redirectUnauthorizedTo = (redirect: any[]) => pipe(loggedIn, map(loggedIn => loggedIn || redirect));
-export const redirectLoggedInTo = (redirect: any[]) =>  pipe(loggedIn, map(loggedIn => loggedIn && redirect || true));
+export const hasCustomClaim: (claim: string) => AuthPipe =
+  (claim) => pipe(customClaims, map(claims =>  claims.hasOwnProperty(claim)));
+export const redirectUnauthorizedTo: (redirect: any[]) => AuthPipe =
+  (redirect) => pipe(loggedIn, map(loggedIn => loggedIn || redirect));
+export const redirectLoggedInTo: (redirect: any[]) => AuthPipe =
+  (redirect) => pipe(loggedIn, map(loggedIn => loggedIn && redirect || true));


### PR DESCRIPTION
Fixes: #2494
Signed-off-by: William Sedlacek <wsedlacekc@gmail.com>

<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: #2494
   - Docs included?: No
   - Test units included?: No
   - In a clean directory, `yarn install`, `yarn test` run successfully? Yes

### Description

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

Adds explicit return types to these helper functions which makes them compatible with `canActivate()` while using strict mode in TypeScript

### Code sample
`hasCustomClaim()`, `redirectUnauthorizedTo()` and `redirectLoggedInTo()` will now all return `AuthPipe` explicitly rather the the inferred type.