### PR TITLE
Corrects typo in analytics/getting-started.md line 125

### DIFF
--- a/docs/analytics/getting-started.md
+++ b/docs/analytics/getting-started.md
@@ -122,7 +122,7 @@ See the gtag.js documentation to learn of the different configuration options at
 
 ### Use DebugView `DEBUG_MODE`
 
-To use [DebugView in Analtyics](https://console.firebase.google.com/project/_/analytics/debugview) set `DEBUG_MODE` to `true` (*default: false*).
+To use [DebugView in Analytics](https://console.firebase.google.com/project/_/analytics/debugview) set `DEBUG_MODE` to `true` (*default: false*).
 
 ### Track deployments with `APP_NAME` and `APP_VERSION`
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: #2510 (required)
   - Docs included?: yes (yes/no; required for all API/functional changes) 
   - Test units included?: no (yes/no; required) 
   - In a clean directory, `yarn install`, `yarn test` run successfully? no (yes/no; required)

### Description

This pull request fixes a documentation typo, in line 125 of _./docs/analytics/getting-started.md_. The word _Analytics_ is misspelled as _Analtyics_.

### Code sample

N/A
