### PR TITLE
fix import in functions docs

### DIFF
--- a/docs/functions/functions.md
+++ b/docs/functions/functions.md
@@ -145,7 +145,7 @@ Next, configure functions origin to point at your app domain:
 
 ```ts
 import { NgModule } from '@angular/core';
-import { AngularFireFunctionsModule, FUNCTIONS_ORIGIN } from '@angular/fire/functions';
+import { AngularFireFunctionsModule, ORIGIN } from '@angular/fire/functions';
 
 @NgModule({
   imports: [


### PR DESCRIPTION
the DI token for functions origin was renamed, this PR fixes the import in docs example