### PR TITLE
docs(auth): update dependency variable

### DIFF
--- a/docs/auth/getting-started.md
+++ b/docs/auth/getting-started.md
@@ -27,13 +27,13 @@ import { auth } from 'firebase/app';
   `,
 })
 export class AppComponent {
-  constructor(public auth: AngularFireAuth) {
+  constructor(public afAuth: AngularFireAuth) {
   }
   login() {
-    this.auth.signInWithPopup(new auth.GoogleAuthProvider());
+    this.afAuth.signInWithPopup(new auth.GoogleAuthProvider());
   }
   logout() {
-    this.auth.signOut();
+    this.afAuth.signOut();
   }
 }
 ```


### PR DESCRIPTION
depending on how you've got TSLint configured, you might have gotten a "shadowed variable" warning on `auth` 

this updates the code to differentiate between the injected AngularFireAuth service, now `afAuth` and the `auth` that we import from firebase