### PR TITLE
fix(analytics): Fix custom data layer function

### DIFF
--- a/src/analytics/analytics.ts
+++ b/src/analytics/analytics.ts
@@ -65,10 +65,11 @@ export class AngularFireAnalytics {
 
     if (!analyticsInitialized) {
       if (isPlatformBrowser(platformId)) {
-        gtag = (window[GTAG_FUNCTION_NAME] as any) || ((...args: any[]) => {
-          (window[DATA_LAYER_NAME] as any).push(args);
-        });
         window[DATA_LAYER_NAME] = window[DATA_LAYER_NAME] || [];
+        // tslint:disable-next-line: only-arrow-functions
+        gtag = (window[GTAG_FUNCTION_NAME] as any) || (function(..._args: any[]) {
+          (window[DATA_LAYER_NAME] as any).push(arguments);
+        });
         analyticsInitialized = zone.runOutsideAngular(() =>
           new Promise(resolve => {
             window[GTAG_FUNCTION_NAME] = (...args: any[]) => {


### PR DESCRIPTION
Change arrow function to a normal function to use the arguments object as described in the gtag documentation. That way, analytics sends data back to Google again.

Fixes #2505

### Checklist

   - Issue number for this PR: #2505 
   - Docs included?: no
   - Test units included?: no
   - In a clean directory, `yarn install`, `yarn test` run successfully? yes

### Description

Since updating to version 6.0.1, analytics no longer sends data to the Firebase Console. Analyzing and debugging this lib I realized that the code that defines a custom datalayer in gtag has been changed from a normal function to an arrow function.
 
After some research I learned that 'arguments' is not an array, it is actually an object that behaves like an array and contains more information besides indexes. 

I'm not sure what the analytics need for this 'arguments' object, but I know that by making this change, the analytics sent the data back to the Console.

