### PR TITLE
fix(analytics): removed providedIn: 'any' from the service injectable

### DIFF
--- a/src/analytics/analytics.service.ts
+++ b/src/analytics/analytics.service.ts
@@ -60,9 +60,7 @@ const getScreenInstanceID = (params: { [key: string]: any }) => {
   }
 };
 
-@Injectable({
-  providedIn: 'any'
-})
+@Injectable()
 export class ScreenTrackingService implements OnDestroy {
 
   private disposable: Subscription | undefined;
@@ -191,9 +189,7 @@ export class ScreenTrackingService implements OnDestroy {
 
 }
 
-@Injectable({
-  providedIn: 'any'
-})
+@Injectable()
 export class UserTrackingService implements OnDestroy {
 
   private disposable: Subscription | undefined;


### PR DESCRIPTION
### Checklist

   - Issue number for this PR: #2604 
   - Docs included?: no
   - Test units included?: no
   - In a clean directory, `yarn install`, `yarn test` run successfully? yes

### Description

The `ScreenTrackingService` and `UserTrackingService` would automatically be initialised even when not provided meaning you cant turn them off. 

### Code sample

Changed from

`@Injectable({
    providedIn: 'any'
})`

to 

`@Injectable()`

