### PR TITLE
fix(auth): declare class before proxy construction

### DIFF
--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -44,6 +44,93 @@ export class AngularFireAuth {
    */
   public readonly idTokenResult: Observable<auth.IdTokenResult|null>;
 
+
+  public applyActionCode: (code: string) => Promise<void> = null;
+
+  public checkActionCode: (code: string) => Promise<firebase.auth.ActionCodeInfo> = null;
+
+  public confirmPasswordReset: (code: string, newPassword: string) => Promise<void> = null;
+
+  public createUserWithEmailAndPassword: (
+    email: string,
+    password: string
+  ) => Promise<firebase.auth.UserCredential> = null;
+
+  public fetchSignInMethodsForEmail: (email: string) => Promise<Array<string>> = null;
+
+  public isSignInWithEmailLink: (emailLink: string) => Promise<boolean> = null;
+
+  public getRedirectResult: () => Promise<firebase.auth.UserCredential> = null;
+
+  public onAuthStateChanged: (
+    nextOrObserver:
+     |firebase.Observer<any>
+     |((a: firebase.User|null) => any),
+    error?: (a: firebase.auth.Error) => any,
+    completed?: firebase.Unsubscribe
+  ) => Promise<firebase.Unsubscribe> = null;
+
+  public onIdTokenChanged: (
+    nextOrObserver:
+     |firebase.Observer<any>
+     |((a: firebase.User|null) => any),
+    error?: (a: firebase.auth.Error) => any,
+    completed?: firebase.Unsubscribe
+  ) => Promise<firebase.Unsubscribe> = null;
+
+  public sendSignInLinkToEmail: (
+    email: string,
+    actionCodeSettings: firebase.auth.ActionCodeSettings
+  ) => Promise<void> = null;
+
+  public sendPasswordResetEmail: (
+    email: string,
+    actionCodeSettings?: firebase.auth.ActionCodeSettings|null
+  ) => Promise<void> = null;
+
+  public setPersistence: (persistence: firebase.auth.Auth.Persistence) => Promise<void> = null;
+
+  public signInAndRetrieveDataWithCredential: (
+    credential: firebase.auth.AuthCredential
+  ) => Promise<firebase.auth.UserCredential> = null;
+
+  public signInAnonymously: () => Promise<firebase.auth.UserCredential> = null;
+
+  public signInWithCredential: (
+    credential: firebase.auth.AuthCredential
+  ) => Promise<firebase.auth.UserCredential> = null;
+
+  public signInWithCustomToken: (token: string) => Promise<firebase.auth.UserCredential> = null;
+
+  public signInWithEmailAndPassword: (
+    email: string,
+    password: string
+  ) => Promise<firebase.auth.UserCredential> = null;
+
+  public signInWithPhoneNumber: (
+    phoneNumber: string,
+    applicationVerifier: firebase.auth.ApplicationVerifier
+  ) => Promise<firebase.auth.ConfirmationResult> = null;
+
+  public signInWithEmailLink: (
+    email: string,
+    emailLink?: string
+  ) => Promise<firebase.auth.UserCredential> = null;
+
+  public signInWithPopup: (
+    provider: firebase.auth.AuthProvider
+  ) => Promise<firebase.auth.UserCredential> = null;
+
+  public signInWithRedirect: (provider: firebase.auth.AuthProvider) => Promise<void> = null;
+
+  public signOut: () => Promise<void> = null;
+
+  public updateCurrentUser: (user: firebase.User|null) => Promise<void> = null;
+
+  public useDeviceLanguage: () => Promise<void> = null;
+
+  public verifyPasswordResetCode: (code: string) => Promise<string> = null;
+
   constructor(
     @Inject(FIREBASE_OPTIONS) options: FirebaseOptions,
     @Optional() @Inject(FIREBASE_APP_NAME) nameOrConfig: string|FirebaseAppConfig|null|undefined,

--- a/src/core/angularfire2.ts
+++ b/src/core/angularfire2.ts
@@ -140,7 +140,7 @@ export const ɵlazySDKProxy = (klass: any, observable: Observable<any>, zone: Ng
       if (klass[name]) {
         return klass[name];
       }
-      if (noopFunctions.includes(name)) {
+      if (noopFunctions.indexOf(name) > -1) {
         return () => {
         };
       }


### PR DESCRIPTION
### Checklist

   - Issue number for this PR:  #2296 
   - Docs included?: not yet
   - Test units included?: not yet
   - In a clean directory, `yarn install`, `yarn test` run successfully? yes

### Description

The new Proxy implementation is not natively compatible with IE11. The recommended polyfill [proxy-polyfill](https://github.com/GoogleChrome/proxy-polyfill) has limitations and requires an object to have all properties assigned at creation time of the new proxy object. 

The AngularFireAuth class inherits from the Auth interface (part of the firebase SDK) and only implements angular specific augmentation to the existing interface. 

This PR re-declares the existing interface from the imported auth.Auth interface and assignes each property with null. This guarantees that properties are known to the proxy and can be invoked using the proxy-polyfill with IE11. 

Further, es5 does not support `Array.prototoype.includes`. I wasn't sure how to workaround this, as the specific use-case is not complex, an indexOf was being used.

### Code sample

N/A
