### PR TITLE
refactor(analytics): Add warning in the code

### DIFF
--- a/src/analytics/analytics.ts
+++ b/src/analytics/analytics.ts
@@ -67,10 +67,10 @@ export class AngularFireAnalytics {
       if (isPlatformBrowser(platformId)) {
         window[DATA_LAYER_NAME] = window[DATA_LAYER_NAME] || [];
         /**
-         * According to the gtag documentation, this function that defines a custom datalayer cannot be
-         * an arrow function because 'arguments' is not an array, it is actually an object that behaves
-         * like an array and contains more information besides indexes. Transform into arrow Funcion
-         * created issue #2505 causing the analytics to no longer send data to the console.
+         * According to the gtag documentation, this function that defines a custom data layer cannot be
+         * an arrow function because 'arguments' is not an array. It is actually an object that behaves
+         * like an array and contains more information then just indexes. Transforming this into arrow function
+         * caused issue #2505 where analytics no longer sent any data.
          */
         // tslint:disable-next-line: only-arrow-functions
         gtag = (window[GTAG_FUNCTION_NAME] as any) || (function(..._args: any[]) {

--- a/src/analytics/analytics.ts
+++ b/src/analytics/analytics.ts
@@ -66,6 +66,12 @@ export class AngularFireAnalytics {
     if (!analyticsInitialized) {
       if (isPlatformBrowser(platformId)) {
         window[DATA_LAYER_NAME] = window[DATA_LAYER_NAME] || [];
+        /**
+         * According to the gtag documentation, this function that defines a custom datalayer cannot be
+         * an arrow function because 'arguments' is not an array, it is actually an object that behaves
+         * like an array and contains more information besides indexes. Transform into arrow Funcion
+         * created issue #2505 causing the analytics to no longer send data to the console.
+         */
         // tslint:disable-next-line: only-arrow-functions
         gtag = (window[GTAG_FUNCTION_NAME] as any) || (function(..._args: any[]) {
           (window[DATA_LAYER_NAME] as any).push(arguments);


### PR DESCRIPTION
Adding a warning in the code so no one can turn the gtag function into an arrow function.

PR #2594

   - Issue number for this PR: #2594
   - Docs included?: no
   - Test units included?: no 
   - In a clean directory, `yarn install`, `yarn test` run successfully? yes

### Description

As requested in the other PR by @Splaktar  I inserted a warning in the code to alert anyone who is going to make changes in analytics about not turning the function into an arrow function
