### PR TITLE
Inherit doc return type from class

### DIFF
--- a/src/firestore/collection/collection.ts
+++ b/src/firestore/collection/collection.ts
@@ -141,7 +141,7 @@ export class AngularFirestoreCollection<T= DocumentData> {
   /**
    * Create a reference to a single document in a collection.
    */
-  doc<T>(path?: string): AngularFirestoreDocument<T> {
-    return new AngularFirestoreDocument<T>(this.ref.doc(path), this.afs);
+  doc<T2 = T>(path?: string): AngularFirestoreDocument<T2> {
+    return new AngularFirestoreDocument<T2>(this.ref.doc(path), this.afs);
   }
 }


### PR DESCRIPTION
### Checklist

   - Issue number for this PR: #2639
   - Docs included?: no
   - Test units included?: no
   - In a clean directory, `yarn install`, `yarn test` run successfully? no

### Description

Updated doc function generic return type to inherit type from class generic

### Code sample
Without this change defining type on `collection` function call does not pass it to `doc` function call:
`db.collection<Location>('locations').doc('someid').valueChanges(); // Returns Observable<unknown>`
`db.collection<Location>('locations').doc<Location>('someid').valueChanges(); // Returns Observable<Location>`

With this PR calling `collection` function with type will pass it to `doc` function call. 
`db.collection<Location>('locations').doc('someid').valueChanges(); // Returns Observable<Location>`
`db.collection<Location>('locations').doc<Location>('someid').valueChanges(); // Returns Observable<Location>`

