### PR TITLE
fix(schematics): remove experimental workspace API type usage

### DIFF
--- a/src/schematics/interfaces.ts
+++ b/src/schematics/interfaces.ts
@@ -74,3 +74,13 @@ export interface FSHost {
   writeFileSync(src: string, data: string): void;
   renameSync(src: string, dest: string): void;
 }
+
+export interface WorkspaceProject {
+  projectType?: string;
+  architect?: Record<string, { builder: string; options?: Record<string, any> }>;
+}
+
+export interface Workspace {
+  defaultProject?: string;
+  projects: Record<string, WorkspaceProject>;
+}

--- a/src/schematics/ng-add-ssr.ts
+++ b/src/schematics/ng-add-ssr.ts
@@ -1,5 +1,4 @@
 import { SchematicsException, Tree, SchematicContext } from '@angular-devkit/schematics';
-import { experimental } from '@angular-devkit/core';
 import {
   addDependencies,
   generateFirebaseRc,
@@ -8,7 +7,7 @@ import {
   safeReadJSON,
   stringifyFormatted
 } from './ng-add-common';
-import { FirebaseJSON } from './interfaces';
+import { FirebaseJSON, Workspace, WorkspaceProject } from './interfaces';
 
 import { default as defaultDependencies, firebaseFunctions as firebaseFunctionsDependencies } from './versions.json';
 import { dirname, join } from 'path';
@@ -16,7 +15,7 @@ import { dirname, join } from 'path';
 // We consider a project to be a universal project if it has a `server` architect
 // target. If it does, it knows how to build the application's server.
 export const isUniversalApp = (
-  project: experimental.workspace.WorkspaceProject
+  project: WorkspaceProject
 ) => project.architect && project.architect.server;
 
 function emptyFirebaseJson(source: string) {
@@ -106,10 +105,10 @@ export const addFirebaseFunctionsDependencies = (tree: Tree, context: SchematicC
 };
 
 export const setupUniversalDeployment = (config: {
-  project: experimental.workspace.WorkspaceProject;
+  project: WorkspaceProject;
   options: NgAddNormalizedOptions;
   workspacePath: string;
-  workspace: experimental.workspace.WorkspaceSchema;
+  workspace: Workspace;
   tree: Tree;
 }) => {
   const { tree, workspacePath, workspace, options } = config;

--- a/src/schematics/ng-add-static.ts
+++ b/src/schematics/ng-add-static.ts
@@ -1,5 +1,4 @@
 import { SchematicsException, Tree, SchematicContext } from '@angular-devkit/schematics';
-import { experimental } from '@angular-devkit/core';
 import {
   addDependencies,
   generateFirebaseRc,
@@ -8,7 +7,7 @@ import {
   safeReadJSON,
   stringifyFormatted
 } from './ng-add-common';
-import { FirebaseJSON } from './interfaces';
+import { FirebaseJSON, Workspace, WorkspaceProject } from './interfaces';
 
 import { default as defaultDependencies } from './versions.json';
 
@@ -82,10 +81,10 @@ export const addFirebaseHostingDependencies = (tree: Tree, context: SchematicCon
 };
 
 export const setupStaticDeployment = (config: {
-  project: experimental.workspace.WorkspaceProject;
+  project: WorkspaceProject;
   options: NgAddNormalizedOptions;
   workspacePath: string;
-  workspace: experimental.workspace.WorkspaceSchema;
+  workspace: Workspace;
   tree: Tree;
 }) => {
   const { tree, workspacePath, workspace, options } = config;

--- a/src/schematics/ng-add.ts
+++ b/src/schematics/ng-add.ts
@@ -1,15 +1,15 @@
 import { SchematicContext, SchematicsException, Tree } from '@angular-devkit/schematics';
 import { NodePackageInstallTask, RunSchematicTask } from '@angular-devkit/schematics/tasks';
-import { experimental, JsonParseMode, parseJson } from '@angular-devkit/core';
+import { JsonParseMode, parseJson } from '@angular-devkit/core';
 import { listProjects, projectPrompt, projectTypePrompt } from './utils';
-
+import { Workspace } from './interfaces';
 import { DeployOptions, NgAddNormalizedOptions } from './ng-add-common';
 import { addFirebaseFunctionsDependencies, setupUniversalDeployment } from './ng-add-ssr';
 import { addFirebaseHostingDependencies, setupStaticDeployment } from './ng-add-static';
 
 function getWorkspace(
   host: Tree
-): { path: string; workspace: experimental.workspace.WorkspaceSchema } {
+): { path: string; workspace: Workspace } {
   const possibleFiles = ['/angular.json', '/.angular.json'];
   const path = possibleFiles.filter(p => host.exists(p))[0];
 
@@ -19,12 +19,12 @@ function getWorkspace(
   }
   const content = configBuffer.toString();
 
-  let workspace: experimental.workspace.WorkspaceSchema;
+  let workspace: Workspace;
   try {
     workspace = (parseJson(
       content,
       JsonParseMode.Loose
-    ) as {}) as experimental.workspace.WorkspaceSchema;
+    ) as {}) as Workspace;
   } catch (e) {
     throw new SchematicsException(`Could not parse angular.json: ` + e.message);
   }

--- a/src/schematics/utils.ts
+++ b/src/schematics/utils.ts
@@ -1,6 +1,5 @@
-import { experimental } from '@angular-devkit/core';
 import { readFileSync } from 'fs';
-import { FirebaseRc, Project } from './interfaces';
+import { FirebaseRc, Project, WorkspaceProject } from './interfaces';
 import { join } from 'path';
 import { isUniversalApp } from './ng-add-ssr';
 
@@ -56,7 +55,7 @@ export const projectPrompt = (projects: Project[]) => {
   });
 };
 
-export const projectTypePrompt = (project: experimental.workspace.WorkspaceProject) => {
+export const projectTypePrompt = (project: WorkspaceProject) => {
   if (isUniversalApp(project)) {
     return require('inquirer').prompt({
       type: 'confirm',


### PR DESCRIPTION
This change removes usage of the experimental workspace API.  Only two types were used within the schematics. The experimental workspace API is no longer present as of Angular v11.