### PR TITLE
Set explicit return on fromTask to avoid errors

### DIFF
--- a/src/storage/observable/fromTask.ts
+++ b/src/storage/observable/fromTask.ts
@@ -1,7 +1,7 @@
 import { Observable } from 'rxjs';
 import { UploadTask, UploadTaskSnapshot } from '../interfaces';
 
-export function fromTask(task: UploadTask) {
+export function fromTask(task: UploadTask): Observable<UploadTaskSnapshot> {
   return new Observable<UploadTaskSnapshot>(subscriber => {
     const progress = (snap: UploadTaskSnapshot) => subscriber.next(snap);
     const error = e => subscriber.error(e);


### PR DESCRIPTION
Hello, I'm not sure if this is the best way to do it, but it sure fixes the problem (builded locally and checked the .d.ts file).

I have explicit set return to avoid d.ts having to direct import firebase like it previosly did and was generating a problem when using `"allowSyntheticDefaultImports": true` on `tsconfig.config` (see https://stackoverflow.com/questions/64655839/angular-firebase-console-error-namespace-firebase-has-no-exported-member-de). I was having the same issue and it was a quick fix.



