### PR TITLE
fix(core): fix the instance cache logic, closes #2666

### DIFF
--- a/sample/src/app/app.module.ts
+++ b/sample/src/app/app.module.ts
@@ -20,7 +20,7 @@ import {
 
 import { FirestoreComponent } from './firestore/firestore.component';
 import { AngularFireDatabaseModule, USE_EMULATOR as USE_DATABASE_EMULATOR } from '@angular/fire/database';
-import { AngularFirestoreModule, USE_EMULATOR as USE_FIRESTORE_EMULATOR } from '@angular/fire/firestore';
+import { AngularFirestoreModule, USE_EMULATOR as USE_FIRESTORE_EMULATOR, SETTINGS as FIRESTORE_SETTINGS } from '@angular/fire/firestore';
 import { AngularFireStorageModule } from '@angular/fire/storage';
 import { AngularFireAuthModule, USE_DEVICE_LANGUAGE, USE_EMULATOR as USE_AUTH_EMULATOR } from '@angular/fire/auth';
 import { AngularFireMessagingModule, SERVICE_WORKER, VAPID_KEY } from '@angular/fire/messaging';
@@ -73,6 +73,7 @@ import { FirestoreOfflineModule } from './firestore-offline/firestore-offline.mo
     UserTrackingService,
     ScreenTrackingService,
     PerformanceMonitoringService,
+    { provide: FIRESTORE_SETTINGS, useValue: { ignoreUndefinedProperties: true } },
     { provide: ANALYTICS_DEBUG_MODE, useValue: true },
     { provide: COLLECTION_ENABLED, useValue: true },
     { provide: USE_AUTH_EMULATOR, useValue: environment.useEmulators ? ['localhost', 9099] : undefined },


### PR DESCRIPTION
It turns out that in sufficiently complex use-cases (e.g, not my sample app) ngc / webpack has now (6.1) decided that our injectables (such as AngularFirestore) can be duplicated... presumably because of something, something, tree-shaking magic formulas.

While I was aware this could happen and intended my instance cache to cover this and the HMR use-case, I had a bug in my fetch logic which would try to reinitialize the SDK instance even when the settings hadn't changed. Whoops. Explains why this wasn't working for HMR users as intended either.