### PR TITLE
fix(afs): fix type in DocumentActions

### DIFF
--- a/src/firestore/observable/fromRef.ts
+++ b/src/firestore/observable/fromRef.ts
@@ -1,6 +1,6 @@
 import { asyncScheduler, Observable, SchedulerLike } from 'rxjs';
 import { Action, DocumentReference, DocumentSnapshot, Query, QuerySnapshot, Reference } from '../interfaces';
-import { map } from 'rxjs/operators';
+import { map, pairwise, startWith } from 'rxjs/operators';
 
 function _fromRef<T, R>(ref: Reference<T>, scheduler: SchedulerLike = asyncScheduler): Observable<R> {
   return new Observable(subscriber => {
@@ -28,7 +28,17 @@ export function fromRef<R, T>(ref: DocumentReference<T> | Query<T>, scheduler?: 
 export function fromDocRef<T>(ref: DocumentReference<T>, scheduler?: SchedulerLike): Observable<Action<DocumentSnapshot<T>>> {
   return fromRef<DocumentSnapshot<T>, T>(ref, scheduler)
     .pipe(
-      map(payload => ({ payload, type: 'value' }))
+      startWith(undefined),
+      pairwise(),
+      map(([priorPayload, payload]) => {
+        if (!payload.exists) {
+          return { payload, type: 'removed' };
+        }
+        if (priorPayload ? !priorPayload.exists : !payload.metadata.fromCache) {
+          return { payload, type: 'added' };
+        }
+        return { payload, type: 'modified' };
+      })
     );
 }
 

--- a/src/firestore/observable/fromRef.ts
+++ b/src/firestore/observable/fromRef.ts
@@ -34,7 +34,7 @@ export function fromDocRef<T>(ref: DocumentReference<T>, scheduler?: SchedulerLi
         if (!payload.exists) {
           return { payload, type: 'removed' };
         }
-        if (priorPayload ? !priorPayload.exists : !payload.metadata.fromCache) {
+        if (!priorPayload?.exists) {
           return { payload, type: 'added' };
         }
         return { payload, type: 'modified' };


### PR DESCRIPTION
Document snapshots will now come with `added`, `removed`, and `modified` types as documented, rather than simply `value`.