### PR TITLE
fix(afs): stateChanges and auditLog correctly emit metadata changes

### DIFF
--- a/sample/src/app/app.component.ts
+++ b/sample/src/app/app.component.ts
@@ -1,5 +1,6 @@
 import { ApplicationRef, Component } from '@angular/core';
 import { FirebaseApp } from '@angular/fire';
+import { debounceTime } from 'rxjs/operators';
 
 @Component({
   selector: 'app-root',
@@ -25,6 +26,6 @@ import { FirebaseApp } from '@angular/fire';
 })
 export class AppComponent {
   constructor(public readonly firebaseApp: FirebaseApp, appRef: ApplicationRef) {
-    appRef.isStable.subscribe(it => console.log('isStable', it));
+    appRef.isStable.pipe(debounceTime(200)).subscribe(it => console.log('isStable', it));
   }
 }

--- a/src/firestore/collection/changes.ts
+++ b/src/firestore/collection/changes.ts
@@ -1,6 +1,6 @@
 import { fromCollectionRef } from '../observable/fromRef';
 import { Observable, SchedulerLike } from 'rxjs';
-import { bufferTime, distinctUntilChanged, map, pairwise, scan, startWith } from 'rxjs/operators';
+import { distinctUntilChanged, map, pairwise, scan, startWith } from 'rxjs/operators';
 import { DocumentChange, DocumentChangeAction, DocumentChangeType, Query } from '../interfaces';
 
 /**
@@ -40,9 +40,6 @@ export function docChanges<T>(query: Query, scheduler?: SchedulerLike): Observab
         }
         return actions as DocumentChangeAction<T>[];
       }),
-      // there are some sync changes firing, esp. when taking over from cache, buffer and flatten them
-      bufferTime(0),
-      map(it => [].concat(...it))
   );
 }
 

--- a/src/firestore/collection/collection.ts
+++ b/src/firestore/collection/collection.ts
@@ -61,6 +61,7 @@ export class AngularFirestoreCollection<T = DocumentData> {
   stateChanges(events?: DocumentChangeType[]): Observable<DocumentChangeAction<T>[]> {
     if (!events || events.length === 0) {
       return docChanges<T>(this.query, this.afs.schedulers.outsideAngular).pipe(
+        filter(changes =>  changes.length > 0),
         this.afs.keepUnstableUntilFirst
       );
     }


### PR DESCRIPTION
* `stateChanges` and `auditLog` will show metadata updates correctly now, rather than just `[]`
* `snapshotChanges` uses same codepath as `stateChanges` and `auditLog`
* filter out empty arrays from `stateChanges`, even when no options provided