### PR TITLE
fix(storage): unsubscribing from the upload progress will not cancel …

### DIFF
--- a/src/storage/observable/fromTask.ts
+++ b/src/storage/observable/fromTask.ts
@@ -1,4 +1,5 @@
 import { Observable } from 'rxjs';
+import { shareReplay } from 'rxjs/operators';
 import { UploadTask, UploadTaskSnapshot } from '../interfaces';
 
 export function fromTask(task: UploadTask) {
@@ -13,6 +14,7 @@ export function fromTask(task: UploadTask) {
       progress(task.snapshot);
       complete();
     });
-    return () => task.cancel();
-  });
+  }).pipe(
+    shareReplay({ bufferSize: 1, refCount: false })
+  );
 }


### PR DESCRIPTION
* unsubscribing from upload progress shouldn't cancel the upload, that was undefined behavior IMO
* shareReplay the upload, so one could pick back up (say if they had upload progress `| async` on a view somewhere)

Closes #2685