### PR TITLE
fix(storage): snapshotChanges should return a success snapshot

### DIFF
--- a/src/storage/observable/fromTask.ts
+++ b/src/storage/observable/fromTask.ts
@@ -1,5 +1,4 @@
 import { Observable } from 'rxjs';
-import { shareReplay } from 'rxjs/operators';
 import { UploadTask, UploadTaskSnapshot } from '../interfaces';
 
 // need to import, else the types become import('firebase/app').default.storage.UploadTask
@@ -11,14 +10,27 @@ export function fromTask(task: UploadTask) {
     const progress = (snap: UploadTaskSnapshot) => subscriber.next(snap);
     const error = e => subscriber.error(e);
     const complete = () => subscriber.complete();
-    task.on('state_changed', progress, (e) => {
-      progress(task.snapshot);
-      error(e);
-    }, () => {
-      progress(task.snapshot);
-      complete();
-    });
-  }).pipe(
-    shareReplay({ bufferSize: 1, refCount: false })
-  );
+    progress(task.snapshot);
+    switch (task.snapshot.state) {
+      case firebase.storage.TaskState.SUCCESS:
+      case firebase.storage.TaskState.CANCELED:
+        complete();
+        break;
+      case firebase.storage.TaskState.ERROR:
+        error(new Error('task was already in error state'));
+        break;
+      default:
+        // on's type if Function, rather than () => void, need to wrap
+        const unsub = task.on('state_changed', progress, (e) => {
+          progress(task.snapshot);
+          error(e);
+        }, () => {
+          progress(task.snapshot);
+          complete();
+        });
+        return function unsubscribe() {
+          unsub();
+        };
+    }
+  });
 }

--- a/src/storage/observable/fromTask.ts
+++ b/src/storage/observable/fromTask.ts
@@ -1,4 +1,5 @@
 import { Observable } from 'rxjs';
+import { debounceTime } from 'rxjs/operators';
 import { UploadTask, UploadTaskSnapshot } from '../interfaces';
 
 // need to import, else the types become import('firebase/app').default.storage.UploadTask
@@ -10,7 +11,13 @@ export function fromTask(task: UploadTask) {
     const progress = (snap: UploadTaskSnapshot) => subscriber.next(snap);
     const error = e => subscriber.error(e);
     const complete = () => subscriber.complete();
+    // emit the current snapshot, so they don't have to wait for state_changes
+    // to fire next
+    progress(task.snapshot);
     const unsub = task.on('state_changed', progress);
+    // it turns out that neither task snapshot nor 'state_changed' fire the last
+    // snapshot before completion, the one with status 'success" and 100% progress
+    // so let's use the promise form of the task for that
     task.then(snapshot => {
       progress(snapshot);
       complete();
@@ -19,5 +26,9 @@ export function fromTask(task: UploadTask) {
     return function unsubscribe() {
       unsub();
     };
-  });
+  }).pipe(
+    // deal with sync emissions from first emitting `task.snapshot`, this makes sure
+    // that if the task is already finished we don't emit the old running state
+    debounceTime(0)
+  );
 }

--- a/src/storage/storage.spec.ts
+++ b/src/storage/storage.spec.ts
@@ -65,16 +65,19 @@ describe('AngularFireStorage', () => {
       const blob = blobOrBuffer(JSON.stringify(data), { type: 'application/json' });
       const ref = afStorage.ref(rando());
       const task = ref.put(blob);
+      let emissionCount = 0;
       let lastSnap: firebase.storage.UploadTaskSnapshot;
       task.snapshotChanges()
         .subscribe(
           snap => {
             lastSnap = snap;
+            emissionCount++;
             expect(snap).toBeDefined();
           },
           done.fail,
           () => {
             expect(lastSnap.state).toBe('success');
+            expect(emissionCount).toBeGreaterThan(0);
             ref.delete().subscribe(done, done.fail);
           });
     });
@@ -113,16 +116,19 @@ describe('AngularFireStorage', () => {
       const blob = blobOrBuffer(JSON.stringify(data), { type: 'application/json' });
       const ref = afStorage.storage.ref(rando());
       const task = ref.put(blob);
+      let emissionCount = 0;
       let lastSnap: firebase.storage.UploadTaskSnapshot;
       task.then(_snap => {
         fromTask(task).subscribe(
             snap => {
               lastSnap = snap;
+              emissionCount++;
               expect(snap).toBeDefined();
             },
             done.fail,
             () => {
               expect(lastSnap.state).toBe('success');
+              expect(emissionCount).toBe(1);
               ref.delete().then(done, done.fail);
             });
       });

--- a/src/storage/storage.spec.ts
+++ b/src/storage/storage.spec.ts
@@ -2,11 +2,12 @@ import { forkJoin } from 'rxjs';
 import { mergeMap, tap } from 'rxjs/operators';
 import { TestBed } from '@angular/core/testing';
 import { AngularFireModule, FIREBASE_APP_NAME, FIREBASE_OPTIONS, FirebaseApp } from '@angular/fire';
-import { AngularFireStorage, AngularFireStorageModule, AngularFireUploadTask, BUCKET } from '@angular/fire/storage';
+import { AngularFireStorage, AngularFireStorageModule, AngularFireUploadTask, BUCKET, fromTask } from '@angular/fire/storage';
 import { COMMON_CONFIG } from '../test-config';
 import { rando } from '../firestore/utils.spec';
 import { ChangeDetectorRef } from '@angular/core';
 import 'firebase/storage';
+import firebase from 'firebase/app';
 
 if (typeof XMLHttpRequest === 'undefined') {
   globalThis.XMLHttpRequest = require('xhr2');
@@ -64,13 +65,16 @@ describe('AngularFireStorage', () => {
       const blob = blobOrBuffer(JSON.stringify(data), { type: 'application/json' });
       const ref = afStorage.ref(rando());
       const task = ref.put(blob);
+      let lastSnap: firebase.storage.UploadTaskSnapshot;
       task.snapshotChanges()
         .subscribe(
           snap => {
+            lastSnap = snap;
             expect(snap).toBeDefined();
           },
           done.fail,
           () => {
+            expect(lastSnap.state).toBe('success');
             ref.delete().subscribe(done, done.fail);
           });
     });
@@ -102,6 +106,26 @@ describe('AngularFireStorage', () => {
         expect(snap).toBeDefined();
         done();
       }).catch(done.fail);
+    });
+
+    it('should work with an already finished task', (done) => {
+      const data = { angular: 'promise' };
+      const blob = blobOrBuffer(JSON.stringify(data), { type: 'application/json' });
+      const ref = afStorage.storage.ref(rando());
+      const task = ref.put(blob);
+      let lastSnap: firebase.storage.UploadTaskSnapshot;
+      task.then(_snap => {
+        fromTask(task).subscribe(
+            snap => {
+              lastSnap = snap;
+              expect(snap).toBeDefined();
+            },
+            done.fail,
+            () => {
+              expect(lastSnap.state).toBe('success');
+              ref.delete().then(done, done.fail);
+            });
+      });
     });
 
   });


### PR DESCRIPTION
Ugh this was still broken. `task.snapshot` and `task.on('state_changed', ...)` never return the "last" snapshot, have to use the promise form of task to get at it.

* Works on tasks that are already running
* Now emits a final success snapshot before completion
* ~~Emits a filterable canceled or error snapshot prior to a throw~~ There appears to be a JS SDK bug blocking this 😢 in theory it should work in a future release
* Added tests for canceling, pausing, and resuming