### PR TITLE
feat(app): provide types for FirebaseOptions and FirebaseAppConfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@angular/platform-browser": "^9.0.0 || ^10.0.0 || ^11.0.0",
     "@angular/platform-browser-dynamic": "^9.0.0 || ^10.0.0 || ^11.0.0",
     "@angular/router": "^9.0.0 || ^10.0.0 || ^11.0.0",
+    "@firebase/app-types": "^0.6.2",
     "firebase": "^7.0 || ^8.0",
     "firebase-admin": "^8.10.0",
     "firebase-functions": "^3.6.0",

--- a/src/core/firebase.app.module.ts
+++ b/src/core/firebase.app.module.ts
@@ -1,16 +1,17 @@
 import {
-  Inject, InjectionToken, isDevMode, ModuleWithProviders, NgModule, NgZone, Optional, PLATFORM_ID, VERSION as NG_VERSION, Version
+  Inject,
+  InjectionToken,
+  isDevMode,
+  ModuleWithProviders,
+  NgModule,
+  NgZone,
+  Optional,
+  PLATFORM_ID,
+  VERSION as NG_VERSION,
+  Version,
 } from '@angular/core';
+import { FirebaseAppConfig, FirebaseOptions } from '@firebase/app-types';
 import firebase from 'firebase/app';
-
-// INVESTIGATE Public types don't expose FirebaseOptions or FirebaseAppConfig, is this the case anylonger?
-export interface FirebaseOptions {
-  [key: string]: any;
-}
-
-export interface FirebaseAppConfig {
-  [key: string]: any;
-}
 
 export const FIREBASE_OPTIONS = new InjectionToken<FirebaseOptions>('angularfire2.app.options');
 export const FIREBASE_APP_NAME = new InjectionToken<string | FirebaseAppConfig | undefined>('angularfire2.app.nameOrConfig');

--- a/src/package.json
+++ b/src/package.json
@@ -27,6 +27,7 @@
     "@angular/core": "ANGULAR_VERSION",
     "@angular/platform-browser": "ANGULAR_VERSION",
     "@angular/platform-browser-dynamic": "ANGULAR_VERSION",
+    "@firebase/app-types": "FIREBASE_APP_TYPES_VERSION",
     "firebase": "FIREBASE_VERSION",
     "rxjs": "RXJS_VERSION"
   },

--- a/test/typings-test/package.sample.json
+++ b/test/typings-test/package.sample.json
@@ -3,13 +3,14 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@angular/firebase": "file:{{ANGULARFIRE_VERSION}}",
-    "firebase": "{{FIREBASE_VERSION}}",
     "@angular/common": "{{ANGULAR_VERSION}}",
     "@angular/compiler": "{{ANGULAR_VERSION}}",
     "@angular/core": "{{ANGULAR_VERSION}}",
-    "@angular/platform-browser": "{{ANGULAR_VERSION}}",
+    "@angular/firebase": "file:{{ANGULARFIRE_VERSION}}",
     "@angular/platform-browser-dynamic": "{{ANGULAR_VERSION}}",
+    "@angular/platform-browser": "{{ANGULAR_VERSION}}",
+    "@firebase/app-types": "{{FIREBASE_APP_TYPES_VERSION}}",
+    "firebase": "{{FIREBASE_VERSION}}",
     "zone.js": "{{ZONE_VERSION}}",
     "rxjs": "{{RXJS_VERSION}}",
     "typescript": "{{TYPESCRIPT_VERSION}}"

--- a/tools/run-typings-test.js
+++ b/tools/run-typings-test.js
@@ -30,6 +30,7 @@ ncp(pathToTestSrcFolder, pathToTestFolder, () => {
   fs.writeFileSync(`${pathToTestFolder}/package.json`, JSON.stringify(samplePackage, null, 2)
     .replace('{{ANGULARFIRE_VERSION}}', path.resolve(__dirname, '../dist/packages-dist'))
     .replace('{{FIREBASE_VERSION}}', rootPackage.dependencies['firebase'])
+    .replace('{{FIREBASE_APP_TYPES_VERSION}}', rootPackage.dependencies['@firebase/app-types'])
     .replace('{{RXJS_VERSION}}', rootPackage.dependencies.rxjs)
     .replace('{{ZONE_VERSION}}', rootPackage.dependencies['zone.js'])
     .replace('{{TYPESCRIPT_VERSION}}', rootPackage.devDependencies.typescript)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1174,6 +1174,11 @@
   resolved "https://registry.yarnpkg.com/@firebase/app-types/-/app-types-0.6.1.tgz#dcbd23030a71c0c74fc95d4a3f75ba81653850e9"
   integrity sha512-L/ZnJRAq7F++utfuoTKX4CLBG5YR7tFO3PLzG1/oXXKEezJ0kRL3CMRoueBEmTCzVb/6SIs2Qlaw++uDgi5Xyg==
 
+"@firebase/app-types@^0.6.2":
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/@firebase/app-types/-/app-types-0.6.2.tgz#8578cb1061a83ced4570188be9e225d54e0f27fb"
+  integrity sha512-2VXvq/K+n8XMdM4L2xy5bYp2ZXMawJXluUIDzUBvMthVR+lhxK4pfFiqr1mmDbv9ydXvEAuFsD+6DpcZuJcSSw==
+
 "@firebase/app@0.6.13":
   version "0.6.13"
   resolved "https://registry.yarnpkg.com/@firebase/app/-/app-0.6.13.tgz#f2e9fa9e75815e54161dc34659a60f1fffd9a450"


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: #nnn (required)
   - Docs included?: no
   - Test units included?: yes
   - In a clean directory, `yarn install`, `yarn test` run successfully? yes

### Description

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

Provide better types for `initializeApp()` by adding as peerDependency the `@firebase/app-types` package.
