### PR TITLE
fix: auth settings setter instead of ovewriting readonly object

### DIFF
--- a/src/auth/auth.spec.ts
+++ b/src/auth/auth.spec.ts
@@ -2,7 +2,7 @@ import firebase from 'firebase/app';
 import { Observable, Subject } from 'rxjs';
 import { TestBed } from '@angular/core/testing';
 import { AngularFireModule, FIREBASE_APP_NAME, FIREBASE_OPTIONS, FirebaseApp } from '@angular/fire';
-import { AngularFireAuth, AngularFireAuthModule } from '@angular/fire/auth';
+import { AngularFireAuth, AngularFireAuthModule, SETTINGS } from '@angular/fire/auth';
 import { COMMON_CONFIG } from '../test-config';
 import 'firebase/auth';
 import { rando } from '../firestore/utils.spec';
@@ -22,6 +22,9 @@ describe('AngularFireAuth', () => {
       imports: [
         AngularFireModule.initializeApp(COMMON_CONFIG, rando()),
         AngularFireAuthModule
+      ],
+      providers: [
+        { provide: SETTINGS, useValue: { appVerificationDisabledForTesting: true } }
       ]
     });
 
@@ -70,6 +73,11 @@ describe('AngularFireAuth', () => {
 
   it('should have an initialized Firebase app', () => {
     expect(afAuth.app).toBeDefined();
+  });
+
+  it('should have disabled app verification for testing', async () => {
+    const app = await afAuth.app;
+    expect(app.auth().settings.appVerificationDisabledForTesting).toBe(true);
   });
 
   it('should emit auth updates through authState', (done: any) => {

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -99,7 +99,7 @@ export class AngularFireAuth {
             auth.useDeviceLanguage();
           }
           if (settings) {
-            auth.settings = settings;
+            auth.settings.appVerificationDisabledForTesting  = settings.appVerificationDisabledForTesting;
           }
           if (persistence) {
             auth.setPersistence(persistence);

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -99,7 +99,9 @@ export class AngularFireAuth {
             auth.useDeviceLanguage();
           }
           if (settings) {
-            auth.settings.appVerificationDisabledForTesting  = settings.appVerificationDisabledForTesting;
+            for (const [k, v] of Object.entries(settings)) {
+              auth.settings[k] = v;
+            }
           }
           if (persistence) {
             auth.setPersistence(persistence);


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: #2826 
   - Docs included?: no
   - Test units included?: yes
   - In a clean directory, `yarn install`, `yarn test` run successfully? yes

### Description

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

Instead of assigning to the auth `settings` readonly object, assign directly the property `appVerificationDisabledForTesting`.