### PR TITLE
update docs/firestore/documents.md

### DIFF
--- a/docs/firestore/documents.md
+++ b/docs/firestore/documents.md
@@ -45,7 +45,7 @@ A `DocumentChangeAction` gives you the `type` and `payload` properties. The `typ
 interface DocumentChangeAction {
   //'added' | 'modified' | 'removed';
   type: DocumentChangeType;
-  payload: DocumentChange;
+  payload: DocumentSnapshot;
 }
 
 interface DocumentChange {


### PR DESCRIPTION
I had this error that doc does not exist on payload anytime I access DocumentData from snapshotChanges().
However, treating payload as  DocumentSnapshot (using the data() method on it directly),
rather than treating it as DocumentChange, solved the problem.

So that's why I feel that the type of payload is DocumentSnapshot and not DocumentChange

<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: #nnn (required)
   - Docs included?: (yes/no; required for all API/functional changes) 
   - Test units included?: (yes/no; required) 
   - In a clean directory, `yarn install`, `yarn test` run successfully? (yes/no; required)

### Description

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->

