### PR TITLE
Fix typo in the migration docs

### DIFF
--- a/docs/version-7-upgrade.md
+++ b/docs/version-7-upgrade.md
@@ -206,8 +206,8 @@ deleteDoc(docRef) // Promise<void>
             <td>
 
 ```ts
-import { collection } from '@angular/fire/firestore';
-collection<T>(docRef, 'bar') // CollectionReference<T>
+import { collectionData } from '@angular/fire/firestore';
+collectionData<T>(collectionRef) // Observable<T>
 ```
 </td>
         </tr>


### PR DESCRIPTION
It's just a typo in the doc