### PR TITLE
Migrate to v7: More complete example

### DIFF
--- a/docs/version-7-upgrade.md
+++ b/docs/version-7-upgrade.md
@@ -53,31 +53,31 @@ import { getMessaging, provideMessaging } from '@angular/fire/messaging';
 import { getPerformance, providePerformance } from '@angular/fire/performance';
 
 @NgModule({
-    imports: [        
+    imports: [
         provideFirebaseApp(() => initializeApp(config)),
         provideAuth(() => {
           const auth = getAuth();
-          if (emulator) connectAuthEmulator(auth, `localhost:${authPort}`);
+          if (emulator) connectAuthEmulator(auth, `http://localhost:${authPort}`);
           return auth;
         }),
         provideDatabase(() => {
           const database = getDatabase();
-          if (emulator) connectDatabaseEmulator(database, 'localhost', databasePort);
+          if (emulator) connectDatabaseEmulator(database, 'http://localhost', databasePort);
           return database;
         }),
         provideFunctions(() => {
           const functions = getFunctions();
-          if (emulator) connectFunctionsEmulator(functions, 'localhost', functionsPort);
+          if (emulator) connectFunctionsEmulator(functions, 'http://localhost', functionsPort);
           return functions;
         }),
         provideStorage(() => {
           const storage = getStorage();
-          if (emulator) connectStorageEmulator(storage, 'localhost', storagePort);
+          if (emulator) connectStorageEmulator(storage, 'http://localhost', storagePort);
           return storage;
         }),
         provideFirestore(() => {
           const firestore = getFirestore();
-          if (emulator) connectFirestoreEmulator(firestore, 'localhost', firestorePort);
+          if (emulator) connectFirestoreEmulator(firestore, 'http://localhost', firestorePort);
           enableIndexedDbPersistence(firestore);
           return firestore;
         }),

--- a/docs/version-7-upgrade.md
+++ b/docs/version-7-upgrade.md
@@ -62,22 +62,22 @@ import { getPerformance, providePerformance } from '@angular/fire/performance';
         }),
         provideDatabase(() => {
           const database = getDatabase();
-          if (emulator) connectDatabaseEmulator(database, 'http://localhost', databasePort);
+          if (emulator) connectDatabaseEmulator(database, 'localhost', databasePort);
           return database;
         }),
         provideFunctions(() => {
           const functions = getFunctions();
-          if (emulator) connectFunctionsEmulator(functions, 'http://localhost', functionsPort);
+          if (emulator) connectFunctionsEmulator(functions, 'localhost', functionsPort);
           return functions;
         }),
         provideStorage(() => {
           const storage = getStorage();
-          if (emulator) connectStorageEmulator(storage, 'http://localhost', storagePort);
+          if (emulator) connectStorageEmulator(storage, 'localhost', storagePort);
           return storage;
         }),
         provideFirestore(() => {
           const firestore = getFirestore();
-          if (emulator) connectFirestoreEmulator(firestore, 'http://localhost', firestorePort);
+          if (emulator) connectFirestoreEmulator(firestore, 'localhost', firestorePort);
           enableIndexedDbPersistence(firestore);
           return firestore;
         }),

--- a/docs/version-7-upgrade.md
+++ b/docs/version-7-upgrade.md
@@ -42,16 +42,48 @@ In order to better support the tree-shakability introduced in Firebase v9 & to r
 
 **Modular SDK:**
 ```ts
+import { initializeApp, provideFirebaseApp } from '@angular/fire/app';
+import { connectAuthEmulator, getAuth, provideAuth } from '@angular/fire/auth';
+import { connectDatabaseEmulator, getDatabase, provideDatabase } from '@angular/fire/database';
+import { connectFirestoreEmulator, getFirestore, provideFirestore } from '@angular/fire/firestore';
+import { connectFunctionsEmulator, getFunctions, provideFunctions } from '@angular/fire/functions';
+import { connectStorageEmulator, getStorage, provideStorage } from '@angular/fire/storage';
+import { getAnalytics, provideAnalytics } from '@angular/fire/analytics';
+import { getMessaging, provideMessaging } from '@angular/fire/messaging';
+import { getPerformance, providePerformance } from '@angular/fire/performance';
+
 @NgModule({
-    imports: [
+    imports: [        
         provideFirebaseApp(() => initializeApp(config)),
-        provideFirestore(() => {
-            const firestore = getFirestore();
-            connectEmulator(firestore, 'localhost', 8080);
-            enableIndexedDbPersistence(firestore);
-            return firestore;
+        provideAuth(() => {
+          const auth = getAuth();
+          if (emulator) connectAuthEmulator(auth, `localhost:${authPort}`);
+          return auth;
         }),
-        provideStorage(() => getStorage()),
+        provideDatabase(() => {
+          const database = getDatabase();
+          if (emulator) connectDatabaseEmulator(database, 'localhost', databasePort);
+          return database;
+        }),
+        provideFunctions(() => {
+          const functions = getFunctions();
+          if (emulator) connectFunctionsEmulator(functions, 'localhost', functionsPort);
+          return functions;
+        }),
+        provideStorage(() => {
+          const storage = getStorage();
+          if (emulator) connectStorageEmulator(storage, 'localhost', storagePort);
+          return storage;
+        }),
+        provideFirestore(() => {
+          const firestore = getFirestore();
+          if (emulator) connectFirestoreEmulator(firestore, 'localhost', firestorePort);
+          enableIndexedDbPersistence(firestore);
+          return firestore;
+        }),
+        provideAnalytics(() => getAnalytics()),
+        providePerformance(() => getPerformance()),
+        provideMessaging(() => getMessaging())
     ],
 })
 ```


### PR DESCRIPTION
connectEmulator does not exist. It's connectFirestoreEmulator. Also I've added an example for all the others. Including auth which has different arguments (port is included in the URL)
