### PR TITLE
Fix properties in deploy schema that require oneOf

### DIFF
--- a/src/schematics/deploy/schema.json
+++ b/src/schematics/deploy/schema.json
@@ -30,7 +30,7 @@
       "pattern": "^[^:\\s]+:[^:\\s]+(:[^\\s]+)?$"
     },
     "ssr": {
-      "type": ["boolean", "string"],
+      "oneOf": [{ "type": "boolean" }, { "type": "string" }],
       "description": "Should we attempt to deploy the function to Cloud Functions (true or 'cloud-functions') / Cloud Run ('cloud-run') or just Hosting (false)"
     },
     "prerender": {
@@ -54,7 +54,7 @@
       "description": "The name of the Cloud Function or Cloud Run serviceId to deploy SSR to"
     },
     "functionsNodeVersion": {
-      "type": ["number", "string"],
+      "oneOf": [{ "type": "number" }, { "type": "string" }],
       "description": "Version of Node.js to run Cloud Functions / Run on"
     },
     "region": {
@@ -82,12 +82,12 @@
           "description": "Set a CPU limit in Kubernetes cpu units."
         },
         "maxConcurrency": {
-          "type": ["number", "string"],
+          "oneOf": [{ "type": "number" }, { "type": "string" }],
           "pattern": "^(\\d+|default)$",
           "description": "Set the maximum number of concurrent requests allowed per container instance. If concurrency is unspecified, any number of concurrent requests are allowed. To unset this field, provide the special value default."
         },
         "maxInstances": {
-          "type": ["number", "string"],
+          "oneOf": [{ "type": "number" }, { "type": "string" }],
           "pattern": "^(\\d+|default)$",
           "description": "The maximum number of container instances of the Service to run. Use 'default' to unset the limit and use the platform default."
         },
@@ -97,7 +97,7 @@
           "description": "Set a memory limit. Ex: 1Gi, 512Mi."
         },
         "minInstances": {
-          "type": ["number", "string"],
+          "oneOf": [{ "type": "number" }, { "type": "string" }],
           "pattern": "^(\\d+|default)$",
           "description": "The minimum number of container instances of the Service to run or 'default' to remove any minimum."
         },


### PR DESCRIPTION
Use `oneOf` instead of `"type": ["a", "b"]` to fix the `ng deploy` command.

Currently, running `ng deploy` with the `@angular/fire:deploy` builder results in the following error:
```
Property 'ssr' does not match the schema.
{
  "type": [
    "boolean",
    "string"
  ],
  "description": "Should we attempt to deploy the function to Cloud Functions (true or 'cloud-functions') / Cloud Run ('cloud-run') or just Hosting (false)"
}'
```

Running the same command with the proposed changes results in a successful deploy.

<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: #3074
   - Docs included?: no
   - Test units included?: no
   - In a clean directory, `yarn install`, `yarn test` run successfully? yes

### Description

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->

