### PR TITLE
Fix for Typescript 4.5 inference breaks in the PromiseProxy

### DIFF
--- a/src/compat/proxy.ts
+++ b/src/compat/proxy.ts
@@ -1,9 +1,11 @@
 import { NgZone } from '@angular/core';
 import { Observable } from 'rxjs';
+import firebase from 'firebase/compat';
 
 type MyFunction = (...args: any[]) => any;
 type FunctionPropertyNames<T> = { [K in keyof T]: T[K] extends MyFunction ? K : never }[keyof T];
 type ReturnTypeOrNever<T> = T extends MyFunction ? ReturnType<T> : never;
+type ParametersOrNever<T> = T extends MyFunction ? Parameters<T> : never;
 type PromiseReturningFunctionPropertyNames<T> = {
   [K in FunctionPropertyNames<T>]: ReturnTypeOrNever<T[K]> extends Promise<any> ? K : never
 }[FunctionPropertyNames<T>];
@@ -13,11 +15,8 @@ type NonPromiseReturningFunctionPropertyNames<T> = {
 type NonFunctionPropertyNames<T> = { [K in keyof T]: T[K] extends MyFunction ? never : K }[keyof T];
 
 export type ɵPromiseProxy<T> = { [K in NonFunctionPropertyNames<T>]: Promise<T[K]> } &
-  { [K in NonPromiseReturningFunctionPropertyNames<T>]:
-    (...args: Parameters<ReturnTypeOrNever<T[K]>>) => Promise<ReturnTypeOrNever<T[K]>> } &
-  { [K in PromiseReturningFunctionPropertyNames<T>]:
-    (...args: Parameters<ReturnTypeOrNever<T[K]>>) => ReturnTypeOrNever<T[K]> };
-
+  { [K in NonPromiseReturningFunctionPropertyNames<T>]: (...args: ParametersOrNever<T[K]>) => Promise<ReturnTypeOrNever<T[K]>> } &
+  { [K in PromiseReturningFunctionPropertyNames<T>]: T[K] };
 
 // DEBUG quick debugger function for inline logging that typescript doesn't complain about
 //       wrote it for debugging the ɵlazySDKProxy, commenting out for now; should consider exposing a

--- a/src/compat/proxy.ts
+++ b/src/compat/proxy.ts
@@ -1,20 +1,22 @@
 import { NgZone } from '@angular/core';
 import { Observable } from 'rxjs';
 
-// tslint:disable:ban-types
-type FunctionPropertyNames<T> = { [K in keyof T]: T[K] extends Function ? K : never }[keyof T];
+type MyFunction = (...args: any[]) => any;
+type FunctionPropertyNames<T> = { [K in keyof T]: T[K] extends MyFunction ? K : never }[keyof T];
+type ReturnTypeOrNever<T> = T extends MyFunction ? ReturnType<T> : never;
 type PromiseReturningFunctionPropertyNames<T> = {
-  [K in FunctionPropertyNames<T>]: ReturnType<T[K]> extends Promise<any> ? K : never
+  [K in FunctionPropertyNames<T>]: ReturnTypeOrNever<T[K]> extends Promise<any> ? K : never
 }[FunctionPropertyNames<T>];
 type NonPromiseReturningFunctionPropertyNames<T> = {
-  [K in FunctionPropertyNames<T>]: ReturnType<T[K]> extends Promise<any> ? never : K
+  [K in FunctionPropertyNames<T>]: ReturnTypeOrNever<T[K]> extends Promise<any> ? never : K
 }[FunctionPropertyNames<T>];
-type NonFunctionPropertyNames<T> = { [K in keyof T]: T[K] extends Function ? never : K }[keyof T];
-// tslint:enable:ban-types
+type NonFunctionPropertyNames<T> = { [K in keyof T]: T[K] extends MyFunction ? never : K }[keyof T];
 
 export type ɵPromiseProxy<T> = { [K in NonFunctionPropertyNames<T>]: Promise<T[K]> } &
-  { [K in NonPromiseReturningFunctionPropertyNames<T>]: (...args: Parameters<T[K]>) => Promise<ReturnType<T[K]>> } &
-  { [K in PromiseReturningFunctionPropertyNames<T>]: (...args: Parameters<T[K]>) => ReturnType<T[K]> };
+  { [K in NonPromiseReturningFunctionPropertyNames<T>]:
+    (...args: Parameters<ReturnTypeOrNever<T[K]>>) => Promise<ReturnTypeOrNever<T[K]>> } &
+  { [K in PromiseReturningFunctionPropertyNames<T>]:
+    (...args: Parameters<ReturnTypeOrNever<T[K]>>) => ReturnTypeOrNever<T[K]> };
 
 
 // DEBUG quick debugger function for inline logging that typescript doesn't complain about

--- a/src/compat/proxy.ts
+++ b/src/compat/proxy.ts
@@ -1,6 +1,5 @@
 import { NgZone } from '@angular/core';
 import { Observable } from 'rxjs';
-import firebase from 'firebase/compat';
 
 type MyFunction = (...args: any[]) => any;
 type FunctionPropertyNames<T> = { [K in keyof T]: T[K] extends MyFunction ? K : never }[keyof T];


### PR DESCRIPTION
Typescript 4.5 changed how inference with extends works, A) don't use `Function` as a type as that's a foot gun B) create a `ReturnTypeOrNever`/`ParametersOrNever` utility types to handle the inference changes. #3090 #3088