### PR TITLE
Proposed CRUD Tutorial

### DIFF
--- a/docs/firestore/crud-tutorial
+++ b/docs/firestore/crud-tutorial
@@ -1,0 +1,792 @@
+# AngularFire CRUD Tutorial: "Greatest Computer Scientists"
+
+### 1. Create a new project
+
+```bash
+npm install -g @angular/cli
+ng new GreatestComputerScientists
+cd GreatestComputerScientists
+```
+
+The Angular CLI's `new` command will set up the latest Angular build in a new project structure.
+
+### 2. Install AngularFire and Firebase
+
+Install AngularFire and Firebase from npm.
+
+```bash
+ng add @angular/fire
+```
+
+Select `Firestore`. This project won't use any other Firebase features.
+
+```bash
+npm install firebase
+```
+
+### 3. Create your Firebase project and add Firebase config to environments variable
+
+Open your Firebase console and make a new project. Call it GreatestComputerScientists.
+
+Open `/src/environments/environment.ts` and add your Firebase configuration. You can find your project configuration in [the Firebase Console](https://console.firebase.google.com). Click the Gear icon next to Project Overview, in the Your Apps section, create a new app and choose the type Web. Give the app a name and copy the config values provided.
+
+```ts
+export const environment = {
+  production: false,
+  firebase: {
+    apiKey: '<your-key>',
+    authDomain: '<your-project-authdomain>',
+    databaseURL: '<your-database-URL>', // no longer provided by Firebase
+    projectId: '<your-project-id>',
+    storageBucket: '<your-storage-bucket>',
+    messagingSenderId: '<your-messaging-sender-id>',
+    appId: '<your-app-id>',
+    measurementId: '<your-measurement-id>'
+  }
+};
+```
+
+### 4. Setup `@NgModule` for the `AngularFireModule`
+
+Open `/src/app/app.module.ts`, inject the Firebase providers, and specify your Firebase configuration.
+
+```ts
+import { BrowserModule } from '@angular/platform-browser';
+import { NgModule } from '@angular/core';
+import { AppComponent } from './app.component';
+import { AngularFireModule } from '@angular/fire/compat';
+import { environment } from '../environments/environment';
+
+@NgModule({
+  imports: [
+    BrowserModule,
+    AngularFireModule.initializeApp(environment.firebase)
+  ],
+  declarations: [ AppComponent ],
+  bootstrap: [ AppComponent ]
+})
+export class AppModule {}
+```
+
+### 5. Setup individual `@NgModule`s
+
+After adding the AngularFireModule you also need to add modules to `app.module.ts` for the individual @NgModules that your application needs.
+
+For example, if your application was using both Google Analytics and the Firestore you would add `AngularFireAnalyticsModule` and `AngularFirestoreModule`.
+
+We'll also need the `FormsModule`.
+
+```ts
+import { BrowserModule } from '@angular/platform-browser';
+import { NgModule } from '@angular/core';
+import { AppComponent } from './app.component';
+import { FormsModule } from '@angular/forms';
+
+//Firebase
+import { AngularFireModule } from '@angular/fire/compat';
+// import { AngularFireAnalyticsModule } from '@angular/fire/compat/analytics';
+import { AngularFirestoreModule } from '@angular/fire/compat/firestore';
+import { environment } from '../environments/environment';
+
+@NgModule({
+  imports: [
+    BrowserModule,
+    FormsModule,
+    AngularFireModule.initializeApp(environment.firebase),
+    AngularFireAnalyticsModule,
+    AngularFirestoreModule
+  ],
+  declarations: [ AppComponent ],
+  bootstrap: [ AppComponent ]
+})
+export class AppModule {}
+```
+
+### 6. Inject `AngularFirestore`
+
+Open `/src/app/app.component.ts` and import `AngularFirestore`.
+
+```ts
+import { Component } from '@angular/core';
+import { AngularFirestore } from '@angular/fire/compat/firestore';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.css']
+})
+export class AppComponent {
+
+  constructor(firestore: AngularFirestore)
+}
+
+```
+
+### 7. Set up Firestore collection
+
+Now open your Firebase Console and create your Firestore database, in test mode. Make a `collection` and call it `greatest-computer-scientists`. Firestore will ask you to make one document. Call the document `Charles Babbage` and put in two fields, both strings:
+
+```
+name: Charles Babbage
+accomplishment: Built first computer
+```
+
+### 8. Bind an Observable to the Firestore collection
+
+Import `Observable` from `rxjs`. Then make an instantiation of the `Observable` class.
+
+In `/src/app/app.component.ts`:
+
+```ts
+import { Component } from '@angular/core';
+import { AngularFirestore } from '@angular/fire/compat/firestore';
+import { Observable } from 'rxjs';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: 'app.component.html',
+  styleUrls: ['app.component.css']
+})
+export class AppComponent {
+  scientists: Observable<any[]>;
+  constructor(private firestore: AngularFirestore) {
+    this.scientists = firestore.collection('greatest-computer-scientists').valueChanges();
+  }
+}
+```
+
+The constructor makes an instantiation of the `AngularFirestore` class and we call it `firestore` for convenience and clarity. You must specify this as `public`, `protected`, or `private`. It doesn't matter which, they all work. It won't work if you don't specify one of these:
+
+```ts
+  constructor(firestore: AngularFirestore) { // doesn't work
+}
+```
+
+I know what you're thinking, the [TypeScript Handbook](https://www.typescriptlang.org/docs/handbook/2/classes.html#public) says
+
+```
+ Because public is already the default visibility modifier, you don’t ever need to write it on a class member.
+```
+
+That's not right, or not right in a way that doesn't require a lot of explaining. Here's a discussion of why we have to [use a visibility modifiers here](https://github.com/angular/angularfire/issues/3173).
+
+Also in the constructor we link to our database. Now we can call our database and store the results in use `this.scientists`.
+
+#### Making an Interface or Type for a Firebase Collection
+
+Did you notice that we set a type to `any`:
+
+```js
+scientists: Observable<any[]>;
+```
+
+TypeScript hates it when we declare `any`. Surely we can declare an `interface` or `type`:
+
+```js
+export declare type Scientists = {
+  accomplishment: string;
+  name: string;
+}
+
+export class HomePageComponent {
+  scientists: Observable<Scientists>;
+}
+
+```
+
+Ah, no. Even for a simple document I've never been able to declare a type that fits a Firebase document. Examining Firebase documents there are hidden properties and metadata that come along with your data. And if your data is nested deeply, declaring a type would be a nightmare. Just use `any` as the type for Firebase documents.
+
+### 9. Make the HTML view
+
+Now we'll make the view in `app.component.html`. Replace the placeholder view with:
+
+```html
+<h2>Who are the greatest computer scientists?</h2>
+
+<h3>Create</h3>
+
+<h3>Read</h3>
+
+<h3>Update</h3>
+
+<h3>Delete</h3>
+```
+
+### 10. Run your app locally
+
+```bash
+ng serve
+```
+
+Your Angular app will compile and serve locally. Visit it we should see the header and subheads.
+
+### 11. READ
+
+Let's start with the `Read` service. Add an `*ngFor` iterator to `app.component.html`:
+
+```html
+<h2>Who are the greatest computer scientists?</h2>
+
+<h3>Create</h3>
+
+<h3>Read</h3>
+<ul>
+  <li *ngFor="let scientist of scientists | async">
+    {{scientist.name}}:
+    {{scientist.accomplishment}}
+  </li>
+</ul>
+
+<h3>Update</h3>
+
+<h3>Delete</h3>
+```
+
+Now you should see `Charles Babbage: Built first computer` in your browser view. This is running Angular's `*ngFor` structural directive to make an unstructured list.
+
+The `| async` pipe is used with an Observable or Promise that binds to an asynchronous source, such as a cloud database.
+
+Firebase has [two types of READ operations](https://firebase.google.com/docs/firestore/query-data/get-data). You can get data once, or set a listener to observe changing data. We'll go into this after we finish the four CRUD operations.
+
+### 12. CREATE in the view
+
+Now we'll add the Create service. Add this to `app.component.html`:
+
+```html
+<h2>Who are the greatest computer scientists?</h2>
+
+<h3>Create</h3>
+<form (ngSubmit)="onCreate()">
+  <input type="text" [(ngModel)]="name" name="name" placeholder="Name" required>
+  <input type="text" [(ngModel)]="accomplishment" name="accomplishment" placeholder="Accomplishment">
+  <button type="submit" value="Submit" >Submit</button>
+</form>
+
+<h3>Read</h3>
+<ul>
+  <li *ngFor="let scientist of scientists | async">
+    {{scientist.name}}:
+    {{scientist.accomplishment}}
+  </li>
+</ul>
+
+<h3>Update</h3>
+
+<h3>Delete</h3>
+```
+
+We're using an HTML form and the Angular `FormsModule`. The form is within the `<form></form>` directive.
+
+```html
+<form (ngSubmit)="onCreate()">
+</form>
+```
+
+The parentheses around `ngSubmit` creates one-way data binding from the view `app.component.html` to the controller `app.component.ts`. When the `Submit` button is clicked the function `onCreate()` executes in `app.component.ts`. We'll make this function next.
+
+Inside the form we have two text field and a `Submit` button. The first text field has two-way data binding (parenthesis and brackets) using `ngModel` to the variable `name` in the controller. The second text field binds to the variable `accomplishment`.
+
+Clicking the button executes `ngSubmit` and the function `onCreate()`.
+
+### 13. CREATE in the controller
+
+Now open `app.component.ts`. Add the two variables and the function:
+
+```ts
+import { Component } from '@angular/core';
+import { AngularFirestore } from '@angular/fire/compat/firestore';
+import { Observable } from 'rxjs';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.css']
+})
+export class AppComponent {
+  scientists: Observable<any[]>;
+  name: string | null = null;
+  accomplishment: string | null = null;
+
+  constructor(public firestore: AngularFirestore) {
+    this.scientists = firestore.collection('greatest-computer-scientists').valueChanges();
+  }
+
+  onCreate() {
+    console.log(this.name);
+    console.log(this.accomplishment);
+    if (this.name != null) {
+      if (this.accomplishment != null) {
+        this.firestore.collection('greatest-computer-scientists').doc(this.name).set({ name: this.name, accomplishment: this.accomplishment })
+          .then(() => {
+            this.name = null;
+            this.accomplishment = null;
+            console.log("Document successfully written!");
+          })
+          .catch((error) => {
+            console.error("Error writing document: ", error);
+          });
+      } else {
+        console.error("Input 'name' is null.");
+      }
+    }
+  }
+}
+```
+
+The two variables `name` and `accomplishment` are strings or null and are initialized as `null`.
+
+The function `onCreate()` first logs the variables so we can see if the data transferred from the view to the controller. The function then checks if `name` and `accomplishment` are null.
+
+If the data is good then we call Firestore and make a document with the name of the computer scientist and two fields, the first for the scientist's name and the second for their accomplishment. Then we reset the variable to null to cleat the fields. Lastly we log success or throw an error.
+
+Now you should be able to add more great computer scientists. Here are some suggestions:
+
+```
+Ada Lovelace: Wrote first software for Charles Babbage's computer
+Alan Turing: First theorized computers with memory and instructions, i.e., general-purpose computers
+John von Neumann: Built first general-purpose computer with memory and instructions
+Donald Knuth: Father of algorithm analysis
+Jeff Dean: Google's smartest computer scientist
+```
+
+#### `add()` vs. `set()`
+
+Firebase `add()` is similar to `set()`. The difference is that `set()` requires that you provide the document name. `add()` creates a document with an auto-generated ID number.
+
+### 14. DELETE in the view
+
+Now we'll add the Delete service to `app.component.html`:
+
+```html
+<h2>Who are the greatest computer scientists?</h2>
+
+<h3>Create</h3>
+<form (ngSubmit)="onCreate()">
+  <input type="text" [(ngModel)]="name" name="name" placeholder="Name" required>
+  <input type="text" [(ngModel)]="accomplishment" name="accomplishment" placeholder="Accomplishment">
+  <button type="submit" value="Submit" >Submit</button>
+</form>
+
+<h3>Read</h3>
+<ul>
+  <li *ngFor="let scientist of scientists | async">
+    {{scientist.name}}:
+    {{scientist.accomplishment}}
+  </li>
+</ul>
+
+<h3>Update</h3>
+
+<h3>Delete</h3>
+<form (ngSubmit)="onDelete()">
+  <select name="scientist" [(ngModel)]="selection">
+    <option *ngFor="let scientist of scientists | async" [ngValue]="scientist">
+      {{ scientist.name }}
+    </option>
+  </select>
+
+  <button type="submit" value="Submit" >Delete</button>
+</form>
+```
+
+This form has a `<select><option>` dropdown menu for selecting a computer scientist to delete. In this we use Angular's `*ngFor` again. Unlike the READ service we must include `[ngValue]="scientist"` in the Delete service. Without this your selection isn't passed back to the controller.
+
+### 15. DELETE in the controller
+
+Now we'll put `onDelete()` into `app.component.ts`:
+
+```ts
+import { Component } from '@angular/core';
+import { AngularFirestore } from '@angular/fire/compat/firestore';
+import { Observable } from 'rxjs';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.css']
+})
+
+export class AppComponent {
+  title = 'angularfire-quickstart';
+
+  scientists: Observable<any[]>;
+  constructor(private firestore: AngularFirestore) {
+    this.scientists = firestore.collection('greatest-computer-scientists').valueChanges();
+  }
+
+  name: string | null = null;
+  accomplishment: string | null = null;
+  selection: { name: string } | null = null;
+
+  onCreate() {
+    console.log(this.name);
+    console.log(this.accomplishment);
+    if (this.name != null) {
+      // if (this.accomplishment != null) {
+      this.firestore.collection('greatest-computer-scientists').doc(this.name).set({ name: this.name, accomplishment: this.accomplishment })
+        .then(() => {
+          this.name = null;
+          this.accomplishment = null;
+          console.log("Document successfully written!");
+        })
+        .catch((error) => {
+          console.error("Error writing document: ", error);
+        });
+      // } else {
+      //   console.error("Input 'accomplisment' is null.");
+      // }
+    } else {
+      console.error("Input 'name' is null.");
+    }
+  }
+
+  onDelete() {
+    if (this.selection != null) {
+      this.firestore.collection('greatest-computer-scientists').doc(this.selection.name).delete()
+        .then(() => {
+          console.log("Document successfully deleted!");
+          // this.selection = null;
+        }).catch((error) => {
+          console.error("Error removing document: ", error);
+        });
+    }
+  }
+}
+```
+
+We've added a variable for `selection`.
+
+We check that the user selected a computer scientist, then we call Firestore and delete the document. We don't need to reset `selection` to null (the HTML form seems to clear itself) but for safety you can uncomment that line.
+
+### 16. UPDATE in the view
+
+Now we'll do the Update service. This is more complicated and we'll get a lesson about Firestore data structure. Add the form to the `app.component.html` view:
+
+```html
+<h2>Who are the greatest computer scientists?</h2>
+
+<h3>Create</h3>
+<form (ngSubmit)="onCreate()">
+  <input type="text" [(ngModel)]="name" name="name" placeholder="Name" required>
+  <input type="text" [(ngModel)]="accomplishment" name="accomplishment" placeholder="Accomplishment">
+  <button type="submit" value="Submit" >Submit</button>
+</form>
+
+<h3>Read</h3>
+<ul>
+  <li *ngFor="let scientist of scientists | async">
+    {{scientist.name}}:
+    {{scientist.accomplishment}}
+  </li>
+</ul>
+
+<h3>Update</h3>
+<form (ngSubmit)="onUpdate()">
+  <select name="scientist" [(ngModel)]="selection">
+    <option *ngFor="let scientist of scientists | async" [ngValue]="scientist">
+      {{ scientist.name }}
+    </option>
+  </select>
+
+  <input type="text" [(ngModel)]="update" name="name" >
+  <button type="submit" value="Submit" >Submit</button>
+</form>
+
+<h3>Delete</h3>
+<form (ngSubmit)="onDelete()">
+  <select name="scientist" [(ngModel)]="selection">
+    <option *ngFor="let scientist of scientists | async" [ngValue]="scientist">
+      {{ scientist.name }}
+    </option>
+  </select>
+
+  <button type="submit" value="Submit" >Delete</button>
+</form>
+```
+
+Now we have two forms, a `<select><option>` to pick the computer scientist and a text field for the new `accomplishment`.
+
+### 17. UPDATE in the controller
+
+Now we'll add the `onUpdate()` function to the `app.component.ts` controller:
+
+```ts
+import { Component } from '@angular/core';
+import { AngularFirestore } from '@angular/fire/compat/firestore';
+import { Observable } from 'rxjs';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.css']
+})
+
+export class AppComponent {
+  title = 'angularfire-quickstart';
+
+  scientists: Observable<any[]>;
+  constructor(private firestore: AngularFirestore) {
+    this.scientists = firestore.collection('greatest-computer-scientists').valueChanges();
+  }
+
+  name: string | null = null;
+  accomplishment: string | null = null;
+  selection: { name: string } | null = null;
+  update: string | null = null;
+
+  onCreate() {
+    console.log(this.name);
+    console.log(this.accomplishment);
+    if (this.name != null) {
+      // if (this.accomplishment != null) {
+      this.firestore.collection('greatest-computer-scientists').doc(this.name).set({ name: this.name, accomplishment: this.accomplishment })
+        .then(() => {
+          this.name = null;
+          this.accomplishment = null;
+          console.log("Document successfully written!");
+        })
+        .catch((error) => {
+          console.error("Error writing document: ", error);
+        });
+      // } else {
+      //   console.error("Input 'accomplisment' is null.");
+      // }
+    } else {
+      console.error("Input 'name' is null.");
+    }
+  }
+
+  onUpdate() {
+    if (this.selection != null) {
+      console.log(this.selection.name);
+      if (this.update != null) {
+        console.log(this.update);
+        this.firestore.collection('greatest-computer-scientists').doc(this.selection.name).update({ accomplishment: this.update })
+          .then(() => {
+            this.update = null;
+            console.log("Document successfully written!");
+          })
+          .catch((error) => {
+            console.error("Error writing document: ", error);
+          });
+      } else {
+        console.error("Input 'update' is null.");
+      }
+    } else {
+      console.error("Input 'selection' is null.");
+    }
+  }
+
+  onDelete() {
+    if (this.selection != null) {
+      this.firestore.collection('greatest-computer-scientists').doc(this.selection.name).delete()
+        .then(() => {
+          console.log("Document successfully deleted!");
+        }).catch((error) => {
+          console.error("Error removing document: ", error);
+        });
+    }
+  }
+}
+```
+
+We make a new variable `update`. We could reuse `accomplishment` but then when we enter a computer scientist's accomplishment into CREATE it will also appear in UPDATE, and vice versa. Also if we make changes in `onCreate()` we might get a bug in `onUpdate()`.
+
+Let's make Charles Babbage's accomplishment more clear. Update his accomplisment to
+
+```
+Attemped to build the first computer from brass, powered by steam
+```
+
+#### `set()` vs. `update()`
+
+`set()` is for creating documents and their fields. `update()` is for updating the fields in an existing document.
+
+If a document doesn't exist, `set()` will create the document. `update()` won't.
+
+If you use `set()` to change one field it will wipe out all the other fields, unless you add `merge`. When you use `update()` on one field it won't change the other fields.
+
+### 18. CRUD accomplished!
+
+Yay! All four CRUD operations should work now.
+
+Let's add another great computer scientist:
+
+```
+Robert Sanders: Invented generalized dynamic instruction handling
+```
+
+Robert Sanders was born in 1938. He worked at IBM and invented generalized dynamic instruction handling? Generalized dynamic instruction handling allows out-of-order execution, used by most modern computer processors to improve performance.
+
+In 1968 Sanders heard about the then-new gender affirmation surgery and decided to become Lynn Conway. IBM fired her and she was legally denied access to her two children. (Robert Sanders had been married to a woman.) IBM apologized to Conway in 2020.
+
+We're not transphobic so we'll update Robert Sanders to Lynn Conway while keeping her accomplishment.
+
+Oh, wait, we can't, or not with the Update service. We'll have to delete Robert Sanders and create Lynn Conway.
+
+Firestore is structured with `collections`, then `documents` in the collections, and then `fields` in the documents. I'm not sure if there's a "best practices" for this but it makes sense to me to update fields but not update documents. If we need to update a document, delete it and make a new document.
+
+Another way would be to not specify document names but instead to allow Firestore to create documents with strings of letters and numbers. This is easy, with just remove `this.name`:
+
+```ts
+this.firestore.collection('greatest-computer-scientists').doc().set({ name: this.name, accomplishment: this.accomplishment })
+```
+
+Then we could update `this.name` and there would be no record of Lynn Conway's birth name. This would make sense in some databases but not in others.
+
+### 19. Get a Document
+
+The Firebase method to get data once is `get()`. For example, to get the Ada Lovelace document, with Web version 8 namespaced syntax:
+
+```js
+firestore.collection('greatest-computer-scientists').doc('Ada Lovelace').get()
+.then((doc) => {
+    if (doc.exists) {
+        console.log("Document data:", doc.data());
+    } else {
+        // doc.data() will be undefined in this case
+        console.log("No such document!");
+    }
+}).catch((error) => {
+    console.log("Error getting document:", error);
+});
+```
+
+With Web version 9 modular syntax, which includes Angular, we would write:
+
+```js
+import { doc, getDoc } from "firebase/firestore";
+
+const docRef = doc(db, "greatest-computer-scientists", "Ada Lovelace");
+const docSnap = await getDoc(docRef);
+
+if (docSnap.exists()) {
+  console.log("Document data:", docSnap.data());
+} else {
+  // doc.data() will be undefined in this case
+  console.log("No such document!");
+}
+```
+
+Firebase supports getting a document, getting multiple documents, getting a collection, getting subcollections of a document, etc.
+
+*AngularFire doesn't support getting data once.* If you need to get Firebase data once from Angular you'll have to do it without AngularFire. I don't know how to access Firebase from Angular without AngularFire and I can't find any documentation showing how.
+
+Let's make a service to get single documents. In the view add another drop-down form:
+
+```html
+<h3>Get Document</h3>
+<form (ngSubmit)="onUpdate()">
+    <select name="scientist" [(ngModel)]="selectedDocument">
+    <option *ngFor="let scientist of scientists | async" [ngValue]="scientist">
+      {{ scientist.name }}
+    </option>
+  </select>
+
+    <button type="submit" value="Submit">Submit</button>
+</form>
+
+<div *ngIf="showDocument">{{showDocument.accomplishment}}</div>
+```
+
+And in the controller add a variable `showDocument` and a handler method `getDocument`:
+
+```ts
+import { Component } from '@angular/core';
+import { AngularFirestore } from '@angular/fire/compat/firestore';
+import { Observable } from 'rxjs';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.css']
+})
+export class AppComponent {
+  scientists: Observable<any[]>;
+  name: string | null = null;
+  accomplishment: string | null = null;
+  selection: { name: string } | null = null;
+  update: string | null = null;
+  showDocument: any | null = null;
+
+  constructor(public firestore: AngularFirestore) {
+    this.scientists = firestore.collection('greatest-computer-scientists').valueChanges();
+  }
+
+  onCreate() {
+    console.log(this.name);
+    console.log(this.accomplishment);
+    if (this.name != null) {
+      if (this.accomplishment != null) {
+        this.firestore.collection('greatest-computer-scientists').doc(this.name).set({ name: this.name, accomplishment: this.accomplishment })
+          .then(() => {
+            this.name = null;
+            this.accomplishment = null;
+            console.log("Document successfully written!");
+          })
+          .catch((error) => {
+            console.error("Error writing document: ", error);
+          });
+      } else {
+        console.error("Input 'name' is null.");
+      }
+    }
+  }
+
+  getDocument() {
+    console.log(this.selection);
+    this.showDocument = this.selection;
+  }
+
+  onUpdate() {
+    if (this.selection != null) {
+      console.log(this.selection.name);
+      if (this.update != null) {
+        console.log(this.update);
+        this.firestore.collection('greatest-computer-scientists').doc(this.selection.name).update({ accomplishment: this.update })
+          .then(() => {
+            this.update = null;
+            console.log("Document successfully written!");
+          })
+          .catch((error) => {
+            console.error("Error writing document: ", error);
+          });
+      } else {
+        console.error("Input 'update' is null.");
+      }
+    } else {
+      console.error("Input 'selection' is null.");
+    }
+  }
+
+  onDelete() {
+    if (this.selection != null) {
+      this.firestore.collection('greatest-computer-scientists').doc(this.selection.name).delete()
+        .then(() => {
+          console.log("Document successfully deleted!");
+          // this.selection = null;
+        }).catch((error) => {
+          console.error("Error removing document: ", error);
+        });
+    }
+  }
+}
+```
+
+We can now get a collection, a document, or a property of a document.
+
+### 20. Firebase Extends Beyond CRUD
+
+CRUD was modeled back when you had to query databases to get data. Firebase pioneered a new type of database, in which data changes in realtime.
+
+For example, let's order a pizza. The GPS device in the driver's phone detects when their car is moving and updates the cloud database with new location data. The database sends the data updates to an app on your phone. Your view updates showing the driver getting closer to your house.
+
+Does the driver click a button to send the GPS data to the cloud database? No. Do you click `Refresh` to see if the cloud database has new data and, if so, download it and update your view? No. Modern apps use Firebase to stream data up and down without queries. This is not any of the four CRUD operations.
+
+I'm going to call these two operations Streaming and Observing. Maybe there are better names, such as data binding.
+
+Looking at our `app.component.ts` controller, we have methods for CREATE, UPDATE, and DELETE. The `getDocument()` method doesn't call Firebase so we'll ignore this now. Our READ operation doesn't query Firebase. It just observes the collection on Firebase. Whenever the database gets new data, the user sees new data in the view.
+
+How about the other direction? Can Firebase observe data in Angular? No, when data changes in Angular you have to send an `update()` query to Firebase.
+
+Firebase has CREATE, READ, UPDATE, DELETE, and OBSERVE, or CRUDO. AngularFire has CREATE, UPDATE, DELETE, and OBSERVE, or C*UDO.


### PR DESCRIPTION
### Description

This new tutorial teaches CREATE, UPDATE, DELETE, and OBSERVABLE operations using AngularFire. A few issues:

- Section 8. I tell readers not to make types or interfaces for Firestore collections, but instead to set the type to `<any>`.

- Section 18. I tell readers that “best practices” is to update properties of documents but not to update documents. Instead, delete the document and make a new document.

- Section 19. I wrote that AngularFire doesn’t have a READ operation. Firebase has `get()` but AngularFire doesn’t support `get()`. Can someone show me how to use Firebase and Angular without AngularFire, to do `get()`? Or is there no use case when we need `get()`?

- Section 20. I wrote that Firebase and AngularFire support Observables for binding data from Firebase to Angular. In other words, AngularFire isn’t CRUD, it’s C*UDO.

- Section 20. I wrote that there’s no Observable in Firebase to watch for changes in Angular. I.e., when your data changes in Angular you have to send an `update()` query to Firebase.

The IntelliJ EduTools plugin makes wonderful tutorials. It makes two panes in the IDE. You read lessons on the right and write code on the left. After each lesson it checks if your code is correct and you can also run the code. The EduTools plugin is available for WebStorm. I’d be happy to set up this tutorial in EduTools for WebStorm but I’m not sure how many people would use it.

If y'all like this tutorial I’ll write a tutorial for Auth OAuth2 providers and another tutorial for Auth email&password.


