### PR TITLE
Update functions.md

### DIFF
--- a/docs/functions/functions.md
+++ b/docs/functions/functions.md
@@ -57,17 +57,37 @@ import { AngularFireFunctions } from '@angular/fire/compat/functions';
 
 @Component({
   selector: 'app-root',
-  template: `{ data$  | async }`
+  template: `{{ data$  | async }}`
 })
 export class AppComponent {
+  data$: any;
+
   constructor(private fns: AngularFireFunctions) { 
-    const callable = fns.httpsCallable('my-fn-name');
+    const callable = this.fns.httpsCallable('myFunctionName');
     this.data$ = callable({ name: 'some-data' });
   }
 }
 ```
 
 Notice that calling `httpsCallable()` does not initiate the request. It creates a function, which when called creates an Observable, subscribe or convert it to a Promise to initiate the request.
+
+### Creating a cloud function
+Create your cloud function in `index.js`:
+
+```js
+// The Cloud Functions for Firebase SDK to create Cloud Functions and set up triggers.
+const functions = require('firebase-functions');
+
+// The Firebase Admin SDK to access Firestore.
+const admin = require('firebase-admin');
+admin.initializeApp();
+
+exports.myFunctionName = functions.https.onCall((data, context) => {
+    console.log("Hello world!")
+    console.log(data);
+    console.log(context);
+});
+```
 
 ## Configuration via Dependency Injection
 


### PR DESCRIPTION
1. template: `{ data$  | async }` was missing a set of curly brackets.
2. `data$` was never declared.
3.  `fns.httpsCallable('myFunctionName');` needs a `this`.
4. Visual Studio Code refused to accept `my-fn-name` as a function name. It tried to put spaces around the dashes and then said `'name' is deprecated`.
5. Let's show a sample `index.js` cloud function.

When I ran `ng serve` the emulator logs showed `Finished "myFunctionName" in 70.938985ms`. I didn't see `Hello world!` in the logs. 

How about putting in a second function that can be called from a button in the HTML view? That's a more common use case than a cloud function that executes when the app starts up.  Something like this:

```js
templateUrl: './app.component.html',
...
  answer: any;

  callMe() {
    console.log("Calling...");
    this.answer = this.functions.httpsCallable('helloWorld');
    this.answer();
  };
```

```html
<div>
    <button mat-raised-button color="basic" (click)='callMe()'>Call me!</button>
</div>
```

```js
exports.helloWorld = fns.https.onCall((data, context) => {
    console.log("Hello world!")
    console.log(data);
    console.log(context);
});
```

I can't get `callMe()` to execute, not sure what's wrong with my code.

I'm also confused about whether we should use AngularFire 7 modules or AngularFire 6 modules with callable functions. In `app.module.ts` I comment out either the AngularFire 7 code or the AngularFire 6 code:

```ts
import { NgModule } from '@angular/core';
import { BrowserModule } from '@angular/platform-browser';
import { AppComponent } from './app.component';
import { environment } from '../environments/environment';

// AngularFire 7
import { initializeApp, provideFirebaseApp } from '@angular/fire/app';
import { provideFirestore, getFirestore } from '@angular/fire/firestore';
import { provideFunctions, getFunctions, connectFunctionsEmulator } from '@angular/fire/functions'; // https://firebase.google.com/docs/emulator-suite/connect_functions#instrument_your_app_to_talk_to_the_emulators

// AngularFire 6
import { AngularFireModule } from '@angular/fire/compat';
import { AngularFireFunctionsModule } from '@angular/fire/compat/functions';
import { USE_EMULATOR as USE_FUNCTIONS_EMULATOR } from '@angular/fire/compat/functions'; // why the alias

@NgModule({
  declarations: [
    AppComponent
  ],
  imports: [
    BrowserModule,

    // AngularFire 7
    provideFirebaseApp(() => initializeApp(environment.firebase)),
    provideFirestore(() => getFirestore()),
    provideFunctions(() => getFunctions())

    // AngularFire 6
    AngularFireModule.initializeApp(environment.firebase),
    AngularFireFunctionsModule
  ],
  providers: [
    { provide: USE_FUNCTIONS_EMULATOR, useValue: ['localhost', 5001] }, // AngularFire 6.1.0 
    // { provide: USE_EMULATOR, useValue: ['localhost', 5001] } // no alias
  ],
  bootstrap: [AppComponent]
})
export class AppModule { }
```

In `app.component.ts`:

```ts
// AngularFire 7
import { getApp } from '@angular/fire/app';
import { provideFunctions, getFunctions, connectFunctionsEmulator, httpsCallable } from '@angular/fire/functions';

// AngularFire 6
import { AngularFireFunctions } from '@angular/fire/compat/functions';
```

The problem here is that `AngularFireFunctions` is available with AngularFire 6 but not AngularFire 7. Is there another type to use with AngularFire 7 in place of `AngularFireFunctions`?

<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: #nnn (required)
   - Docs included?: (no; required for all API/functional changes) 
   - Test units included?: (no; required) 
   - In a clean directory, `yarn install`, `yarn test` run successfully? (no; required)

### Description

Updating the documentation for the callable cloud functions section.

