### PR TITLE
auth emulator provider needs http://

### DIFF
--- a/docs/emulators/emulators.md
+++ b/docs/emulators/emulators.md
@@ -78,7 +78,7 @@ import { USE_EMULATOR as USE_FUNCTIONS_EMULATOR } from '@angular/fire/compat/fun
   // ... Existing configuration
   providers: [
     // ... Existing Providers
-    { provide: USE_AUTH_EMULATOR, useValue: environment.useEmulators ? ['localhost', 9099] : undefined },
+    { provide: USE_AUTH_EMULATOR, useValue: environment.useEmulators ? ['http://localhost', 9099] : undefined },
     { provide: USE_DATABASE_EMULATOR, useValue: environment.useEmulators ? ['localhost', 9000] : undefined },
     { provide: USE_FIRESTORE_EMULATOR, useValue: environment.useEmulators ? ['localhost', 8080] : undefined },
     { provide: USE_FUNCTIONS_EMULATOR, useValue: environment.useEmulators ? ['localhost', 5001] : undefined },


### PR DESCRIPTION
### Description

This is a simple docs update, the auth emulator needs http:// in the providers for the app modules

