### PR TITLE
Fix example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ export class AppComponent {
 
   constructor() {
     const itemCollection = collection(this.firestore, 'items');
-    this.item$ = collectionData(collection);
+    this.item$ = collectionData<Item>(itemCollection);
   }
 }
 ```


### PR DESCRIPTION
### Description

The example was incorrect in two ways:

- `collectionData` wasn't using its generic
- `itemCollection` wasn't used, instead `collection` was being passed incorrectly to `collectionData` 

This PR addresses that in such a way that the example should now be more accurate.

