### PR TITLE
fix: remove unsupported function from appcheck example

### DIFF
--- a/docs/app-check.md
+++ b/docs/app-check.md
@@ -20,7 +20,7 @@ Provide an App Check instance and configuration in the application's `NgModule` 
 
 ```ts
 import { provideFirebaseApp, initializeApp } from '@angular/fire/app';
-import { getAppCheck, provideAppCheck } from '@angular/fire/app-check';
+import { provideAppCheck } from '@angular/fire/app-check';
 
 @NgModule({
   imports: [


### PR DESCRIPTION


### Checklist

   - Issue number for this PR: #3377
   - Docs included?: no
   - Test units included?: no
   - In a clean directory, `yarn install`, `yarn test` run successfully? yes

### Description

Documentation update: remove unsupported function from appcheck example


