### PR TITLE
fix: guard HMR check for non-Webpack builds

### DIFF
--- a/src/compat/cache.ts
+++ b/src/compat/cache.ts
@@ -23,7 +23,7 @@ function matchDep(a: any, b: any) {
   }
 }
 
-const IS_HMR = !!(module as any).hot;
+const IS_HMR = typeof module !== 'undefined' && !!(module as any).hot;
 
 const log = (level: 'log'|'error'|'info'|'warn', ...args: any) => {
   if (isDevMode() && typeof console !== 'undefined') {


### PR DESCRIPTION
`module` is present in CommonJS but not ESM and `module.hot` is specific to Webpack. Adding a guard will prevent runtime crashes when non-Webpack bundlers are used.