### PR TITLE
Cast collectionData to avoid TS errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ export class AppComponent {
 
   constructor() {
     const itemCollection = collection(this.firestore, 'items');
-    this.item$ = collectionData(itemCollection);
+    this.item$ = collectionData(itemCollection) as Observable<Item[]>;
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ export class AppComponent {
 
   constructor() {
     const itemCollection = collection(this.firestore, 'items');
-    this.item$ = collectionData(itemCollection) as Observable<Item[]>;
+    this.item$ = collectionData<Item>(itemCollection);
   }
 }
 ```


### PR DESCRIPTION
Using the current code example, I am getting an error message Typescript error message like: 

```
Type 'Observable<(DocumentData | (DocumentData & { .... }))[]>' is not assignable to type 'Observable<Item[]>'.
```

This change also makes this code example more consistent with the current example in [firestore.md](https://github.com/angular/angularfire/blob/5793d6f3a15aa61660af75ab361c534cde9b73df/docs/firestore.md?plain=1#L91)

<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: none. 
   - Docs included?: yes.
   - Test units included?: no
   - In a clean directory, `yarn install`, `yarn test` run successfully? yes.

### Description

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->

