### PR TITLE
fix typo in builder.ts:32

### DIFF
--- a/src/schematics/deploy/builder.ts
+++ b/src/schematics/deploy/builder.ts
@@ -25,7 +25,7 @@ export default createBuilder(
       throw new Error('The Firebase Project specified by your angular.json or .firebaserc is in conflict');
     }
 
-    const firebaseHostingSite = options.firebaseHostingSite || defulatFirebaseHostingSite;
+    const firebaseHostingSite = options.firebaseHostingSite || defaultFirebaseHostingSite;
     if (!firebaseHostingSite) {
       throw new Error(`Cannot determine the Firebase Hosting Site from your angular.json or .firebaserc`);
     }


### PR DESCRIPTION
I'm a novice at angular and I came across this typo. I'll be honest, I'm not 100% how to properly do linter & test stuff, but it's a pretty simple typo that's being fixed. I filled out the CLA, so please let me know if I need to do anything else!

<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: #nnn (required)
   - Docs included?: (yes/no; required for all API/functional changes) 
   - Test units included?: (yes/no; required) 
   - In a clean directory, `yarn install`, `yarn test` run successfully? (yes/no; required)

### Description

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->

