### PR TITLE
chore(sample): replace deprecated provideServerRoutesConfig with provideServerRouting

### DIFF
--- a/sample/src/app/app.config.server.ts
+++ b/sample/src/app/app.config.server.ts
@@ -1,7 +1,7 @@
 import { mergeApplicationConfig, ApplicationConfig, inject, REQUEST_CONTEXT } from '@angular/core';
 import { initializeServerApp, provideFirebaseApp } from '@angular/fire/app';
 import { provideServerRendering } from '@angular/platform-server';
-import { provideServerRoutesConfig } from '@angular/ssr';
+import { provideServerRouting } from '@angular/ssr';
 
 import { appConfig } from './app.config';
 import { serverRoutes } from './app.routes.server';
@@ -10,7 +10,7 @@ import { environment } from '../environments/environment';
 const serverConfig: ApplicationConfig = {
   providers: [
     provideServerRendering(),
-    provideServerRoutesConfig(serverRoutes),
+    provideServerRouting(serverRoutes),
     provideFirebaseApp(() => {
       // TODO migrate to REQUEST once that's working
       const requestContext = inject(REQUEST_CONTEXT, { optional: true }) as {


### PR DESCRIPTION
Thanks for the amazing samples.
I'm using them and I found this improvement :100: 

[provideServerRoutesConfig](https://next.angular.dev/api/ssr/provideServerRoutesConfig) is deprecated so I replaced it with [provideServerRouting](https://next.angular.dev/api/ssr/provideServerRouting)

![image](https://github.com/user-attachments/assets/9353893c-a4e4-48c1-a35b-3e1d5bf65d1b)


<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - [X] In a clean directory, `yarn install`, `yarn test` run successfully