### PR TITLE
fix: Avoid handling promise rejections twice in stability helper

### DIFF
--- a/src/zones.ts
+++ b/src/zones.ts
@@ -170,12 +170,12 @@ export const ɵzoneWrap = <T= unknown>(it: T, blockUntilFirst: boolean, logLevel
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
       return run(
         () => {
-          pendingTasks.run(() => ret);
+          const removeTask = pendingTasks.add();
           return new Promise((resolve, reject) => {
             ret.then(
               (it) => runInInjectionContext(injector, () => run(() => resolve(it))),
               (reason) => runInInjectionContext(injector, () => run(() => reject(reason)))
-            )
+            ).finally(removeTask);
         });
       });
     } else if (typeof ret === 'function' && taskDone) {


### PR DESCRIPTION
`PendingTasks.run` reports rejections of the promise to the `ErrorHandler`. This function already returns a promise that is meant to be handled in the developer's application. If there _is_ handling there, the rejection is handled both in the `PendingTasks.run` and in the developer callsite.

This change updates the code to use `PendingTasks.add` instead, which has no built in error handling mechanisms.

fixes https://github.com/angular/angular/issues/61932
