### PR TITLE
fix(schematics): accept firebase-tools 15 in the peer range

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -29,7 +29,7 @@
     "@angular/platform-browser-dynamic": "^21.0.0",
     "@angular/platform-server": "^21.0.0",
     "rxjs": "~7.8.0",
-    "firebase-tools": "^14.0.0"
+    "firebase-tools": "^14.0.0 || ^15.0.0"
   },
   "peerDependenciesMeta": {
     "firebase-tools": { "optional": true },


### PR DESCRIPTION
The optional `firebase-tools` peerDependency was capped at `^14.0.0`, excluding the current major (15.x). The `ng add` version check already accepts anything `>= 14.0.0` and the schematic runs fine on 15.x, so the narrow range only produces spurious peer-dependency warnings for users on the current CLI.

Widens the range to `^14.0.0 || ^15.0.0`.

Fixes #3701
