### PR TITLE
refactor(schematics): derive the firebase-tools version message from a shared constant

### DIFF
--- a/src/schematics/firebaseTools.ts
+++ b/src/schematics/firebaseTools.ts
@@ -8,6 +8,9 @@ declare global {
     var firebaseTools: FirebaseTools|undefined;
 }
 
+// The minimum firebase-tools version the schematics require.
+const minFirebaseToolsVersion = '14.0.0';
+
 export const getFirebaseTools = () => globalThis.firebaseTools ?
     Promise.resolve(globalThis.firebaseTools) :
     new Promise<FirebaseTools>((resolve, reject) => {
@@ -44,8 +47,8 @@ export const getFirebaseTools = () => globalThis.firebaseTools ?
         globalThis.firebaseTools = firebaseTools;
         const version = firebaseTools.cli.version();
         console.log(`Using firebase-tools version ${version}`);
-        if (semverCompare(version, '14.0.0') === -1) {
-            console.error('firebase-tools version 14.0.0+ is required, please upgrade and run again');
+        if (semverCompare(version, minFirebaseToolsVersion) === -1) {
+            console.error(`firebase-tools version ${minFirebaseToolsVersion}+ is required, please upgrade and run again`);
             return Promise.reject();
         }
         return firebaseTools;


### PR DESCRIPTION
Follow-up to #3662. The firebase-tools minimum-version check and its error message were separate string literals that drifted once (the message read "13.0.0+" after the check was raised to 14). This derives the message from a single `minFirebaseToolsVersion` constant so the two stay in sync. No behavior change.

Fixes #3703
