### PR TITLE
build: declare the ES2022 standard library in the tsconfigs

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -18,7 +18,7 @@
         "node_modules/@types"
       ],
       "lib": [
-        "es2018",
+        "es2022",
         "dom"
       ],
       "paths": {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -5,7 +5,7 @@
     "compilerOptions": {
         "outDir": "tools",
         "skipLibCheck": true,
-        "lib": ["es2019", "dom"],
+        "lib": ["es2022", "dom"],
         "module": "commonjs",
         "target": "ES2020",
         "plugins": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     ],
     "lib": [
       "dom",
-      "es2018"
+      "es2022"
     ]
   },
   "angularCompilerOptions": {


### PR DESCRIPTION
The tsconfig `lib` declarations (`es2018` in the root and base configs, `es2019` in `tsconfig.build.json`) understate every runtime this project supports — Node 20+ in CI and the browsers Angular 21 supports all provide ES2022, and the Angular CLI generates new workspaces at ES2022. This also resolves the inconsistency of `target: es2020` sitting alongside `lib: es2018`.

Type-checking declaration only; compilation targets are unchanged, so emitted code is identical.

Fixes #3705
