### PR TITLE
fix(schematics): only emit FirebaseOptions keys in the generated app config

### DIFF
--- a/src/schematics/setup/index.ts
+++ b/src/schematics/setup/index.ts
@@ -18,6 +18,12 @@ import {
 } from '../utils';
 import { appPrompt, featuresPrompt, projectPrompt, userPrompt } from './prompts';
 
+// FirebaseOptions keys — apps.sdkconfig responses include management-API extras that initializeApp() rejects.
+const firebaseOptionsKeys = [
+  'apiKey', 'authDomain', 'databaseURL', 'projectId', 'storageBucket',
+  'messagingSenderId', 'appId', 'measurementId', 'recaptchaSiteKey',
+];
+
 export interface SetupConfig extends DeployOptions {
   firebaseProject: FirebaseProject,
   firebaseApp?: FirebaseApp,
@@ -92,8 +98,11 @@ export const ngAddSetupProject = (
       firebaseApp = await appPrompt(firebaseProject, undefined, { projectRoot });
 
       const result = await firebaseTools.apps.sdkconfig('web', firebaseApp.appId, { nonInteractive: true, projectRoot });
-      sdkConfig = result.sdkConfig;
-      delete sdkConfig.locationId;
+      sdkConfig = Object.fromEntries(
+        firebaseOptionsKeys
+          .filter(key => result.sdkConfig[key] !== undefined)
+          .map(key => [key, result.sdkConfig[key]])
+      );
       setupConfig.sdkConfig = sdkConfig;
       setupConfig.firebaseApp = firebaseApp;
       // set up data connect locally if data connect hasn't already been initialized.


### PR DESCRIPTION
`ng add @angular/fire` inlines the Firebase CLI's `apps.sdkconfig` response into `initializeApp()`. That response includes management-API fields (`projectNumber`, `version`, `locationId`) that `FirebaseOptions` does not accept; only `locationId` was being stripped (added for #3452 / #3556), so the generated app fails to compile with `TS2769: 'projectNumber' does not exist in type 'FirebaseOptions'`. This is the third report of the class.

This replaces the single-key delete with an allowlist of the keys `initializeApp()` accepts, so future additions to the CLI response can't break the generated config.

Companion PR #3706 declares the ES2022 lib the `Object.fromEntries` here relies on (IDE-only; not required for CI).

Fixes #3675
