### PR TITLE
fix(schematics): log the caught error when dataconnect.yaml parsing fails

### DIFF
--- a/src/schematics/utils.ts
+++ b/src/schematics/utils.ts
@@ -375,7 +375,7 @@ export function parseDataConnectConfig(
       package: connectorJson.generate.javascriptSdk.package,
       angular: connectorJson.generate.javascriptSdk.angular,
     };
-  } catch (_) {
+  } catch (e) {
     console.error("Couldn't parse dataconnect.yaml", e);
     return null;
   }


### PR DESCRIPTION
Fixes #3710

One-line fix: the catch handler in `parseDataConnectConfig` names its error variable `_` but logs `e`, which is undefined — so the intended soft-fail path (warn and return `null`) instead crashes the schematic with a `ReferenceError`. Renaming the variable to `e` makes the handler do what it was written to do.

No behavior change on the success path. The file isn't covered by any typecheck today (the library build excludes the schematics; esbuild doesn't check types), which is how this survived — a `tsc --noEmit` pass over `src/schematics` would catch this class of bug at build time.
