### PR TITLE
feat(schematics): generate .firebaserc and Firestore starter files during ng add

### DIFF
--- a/src/schematics/interfaces.ts
+++ b/src/schematics/interfaces.ts
@@ -155,9 +155,15 @@ export interface DataConnectConfig {
   source?: string;
 }
 
+export interface FirebaseFirestoreConfig {
+  rules?: string;
+  indexes?: string;
+}
+
 export interface FirebaseJSON {
   hosting?: FirebaseHostingConfig[] | FirebaseHostingConfig;
   functions?: FirebaseFunctionsConfig;
+  firestore?: FirebaseFirestoreConfig;
   dataconnect?: DataConnectConfig;
 }
 

--- a/src/schematics/setup/firebaseConfigs.jasmine.ts
+++ b/src/schematics/setup/firebaseConfigs.jasmine.ts
@@ -1,0 +1,168 @@
+import { mkdtempSync, readFileSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { logging } from '@angular-devkit/core';
+import { HostTree, SchematicContext } from '@angular-devkit/schematics';
+import fsExtra from 'fs-extra';
+import { FEATURES } from '../interfaces.js';
+import {
+  addFirestoreToFirebaseJson,
+  createFirestoreStarterFiles,
+  setDefaultProjectInFirebaseRc,
+} from './firebaseConfigs.js';
+import 'jasmine';
+
+const context = { logger: new logging.Logger('test') } as unknown as SchematicContext;
+
+describe('setDefaultProjectInFirebaseRc', () => {
+  let projectRoot: string;
+
+  beforeEach(() => {
+    projectRoot = mkdtempSync(join(tmpdir(), 'angularfire-test-'));
+  });
+
+  afterEach(() => {
+    fsExtra.removeSync(projectRoot);
+  });
+
+  const firebaseRcOnDisk = () =>
+    JSON.parse(readFileSync(join(projectRoot, '.firebaserc')).toString());
+
+  it('creates .firebaserc recording the selected project as default', () => {
+    setDefaultProjectInFirebaseRc(projectRoot, 'my-project');
+    expect(firebaseRcOnDisk()).toEqual({
+      projects: { default: 'my-project' },
+    });
+  });
+
+  it('merges into an existing .firebaserc, preserving targets and other aliases', () => {
+    writeFileSync(join(projectRoot, '.firebaserc'), JSON.stringify({
+      projects: { default: 'old-project', staging: 'staging-project' },
+      targets: { 'old-project': { hosting: { app: ['app-site'] } } },
+    }));
+    setDefaultProjectInFirebaseRc(projectRoot, 'new-project');
+    expect(firebaseRcOnDisk()).toEqual({
+      projects: { default: 'new-project', staging: 'staging-project' },
+      targets: { 'old-project': { hosting: { app: ['app-site'] } } },
+    });
+  });
+
+  it('names the file when an existing .firebaserc cannot be parsed', () => {
+    writeFileSync(join(projectRoot, '.firebaserc'), '{ not json');
+    expect(() => setDefaultProjectInFirebaseRc(projectRoot, 'my-project'))
+      .toThrowError(/\.firebaserc/);
+  });
+
+});
+
+describe('createFirestoreStarterFiles', () => {
+
+  it('creates test-mode rules and an empty index manifest when Firestore is selected', () => {
+    const tree = new HostTree();
+    createFirestoreStarterFiles(tree, context, [FEATURES.Firestore]);
+    const rules = tree.readText('/firestore.rules');
+    expect(rules).toContain("rules_version='2'");
+    expect(rules).toContain('allow read, write: if request.time < timestamp.date(');
+    expect(JSON.parse(tree.readText('/firestore.indexes.json'))).toEqual({
+      indexes: [],
+      fieldOverrides: [],
+    });
+  });
+
+  it('sets the rules to expire roughly 30 days out', () => {
+    const tree = new HostTree();
+    createFirestoreStarterFiles(tree, context, [FEATURES.Firestore]);
+    const match = /timestamp\.date\((\d+), (\d+), (\d+)\)/.exec(tree.readText('/firestore.rules'));
+    expect(match).not.toBeNull();
+    const [, year, month, day] = match.map(Number);
+    const expiry = new Date(year, month - 1, day);
+    const daysOut = (expiry.getTime() - Date.now()) / (1000 * 60 * 60 * 24);
+    expect(daysOut).toBeGreaterThan(28);
+    expect(daysOut).toBeLessThan(31);
+  });
+
+  it('never overwrites an existing rules file', () => {
+    const tree = new HostTree();
+    tree.create('/firestore.rules', 'my existing rules');
+    createFirestoreStarterFiles(tree, context, [FEATURES.Firestore]);
+    expect(tree.readText('/firestore.rules')).toBe('my existing rules');
+  });
+
+  it('still creates the index manifest when only the rules file exists', () => {
+    const tree = new HostTree();
+    tree.create('/firestore.rules', 'my existing rules');
+    createFirestoreStarterFiles(tree, context, [FEATURES.Firestore]);
+    expect(tree.exists('/firestore.indexes.json')).toBeTrue();
+  });
+
+  it('does nothing when Firestore is not selected', () => {
+    const tree = new HostTree();
+    createFirestoreStarterFiles(tree, context, [FEATURES.Authentication]);
+    expect(tree.exists('/firestore.rules')).toBeFalse();
+    expect(tree.exists('/firestore.indexes.json')).toBeFalse();
+  });
+
+  it('creates nothing when firebase.json already has a firestore section', () => {
+    const tree = new HostTree();
+    createFirestoreStarterFiles(tree, context, [FEATURES.Firestore], {
+      firestore: { rules: 'custom.rules' },
+    });
+    expect(tree.exists('/firestore.rules')).toBeFalse();
+    expect(tree.exists('/firestore.indexes.json')).toBeFalse();
+  });
+
+});
+
+describe('addFirestoreToFirebaseJson', () => {
+  let projectRoot: string;
+
+  beforeEach(() => {
+    projectRoot = mkdtempSync(join(tmpdir(), 'angularfire-test-'));
+  });
+
+  afterEach(() => {
+    fsExtra.removeSync(projectRoot);
+  });
+
+  const firebaseJsonOnDisk = () =>
+    JSON.parse(readFileSync(join(projectRoot, 'firebase.json')).toString());
+
+  it('adds the firestore section pointing at the starter files', () => {
+    writeFileSync(join(projectRoot, 'firebase.json'), '{}');
+    addFirestoreToFirebaseJson(projectRoot, context, [FEATURES.Firestore]);
+    expect(firebaseJsonOnDisk().firestore).toEqual({
+      rules: 'firestore.rules',
+      indexes: 'firestore.indexes.json',
+    });
+  });
+
+  it('preserves sections other tools wrote to firebase.json', () => {
+    writeFileSync(join(projectRoot, 'firebase.json'), JSON.stringify({
+      dataconnect: { source: 'dataconnect' },
+    }));
+    addFirestoreToFirebaseJson(projectRoot, context, [FEATURES.Firestore]);
+    expect(firebaseJsonOnDisk().dataconnect).toEqual({ source: 'dataconnect' });
+    expect(firebaseJsonOnDisk().firestore).toBeDefined();
+  });
+
+  it('leaves an existing firestore section untouched', () => {
+    writeFileSync(join(projectRoot, 'firebase.json'), JSON.stringify({
+      firestore: { rules: 'custom.rules' },
+    }));
+    addFirestoreToFirebaseJson(projectRoot, context, [FEATURES.Firestore]);
+    expect(firebaseJsonOnDisk().firestore).toEqual({ rules: 'custom.rules' });
+  });
+
+  it('does nothing when Firestore is not selected', () => {
+    writeFileSync(join(projectRoot, 'firebase.json'), '{}');
+    addFirestoreToFirebaseJson(projectRoot, context, [FEATURES.Authentication]);
+    expect(firebaseJsonOnDisk().firestore).toBeUndefined();
+  });
+
+  it('warns and skips when firebase.json cannot be read', () => {
+    const warnSpy = spyOn(context.logger, 'warn');
+    addFirestoreToFirebaseJson(projectRoot, context, [FEATURES.Firestore]);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+});

--- a/src/schematics/setup/firebaseConfigs.jasmine.ts
+++ b/src/schematics/setup/firebaseConfigs.jasmine.ts
@@ -165,4 +165,12 @@ describe('addFirestoreToFirebaseJson', () => {
     expect(warnSpy).toHaveBeenCalled();
   });
 
+  it('warns and skips when firebase.json parses to a non-object', () => {
+    writeFileSync(join(projectRoot, 'firebase.json'), 'null');
+    const warnSpy = spyOn(context.logger, 'warn');
+    addFirestoreToFirebaseJson(projectRoot, context, [FEATURES.Firestore]);
+    expect(warnSpy).toHaveBeenCalled();
+    expect(readFileSync(join(projectRoot, 'firebase.json')).toString()).toBe('null');
+  });
+
 });

--- a/src/schematics/setup/firebaseConfigs.ts
+++ b/src/schematics/setup/firebaseConfigs.ts
@@ -1,0 +1,119 @@
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { SchematicContext, SchematicsException, Tree } from '@angular-devkit/schematics';
+import { stringifyFormatted } from '../common.js';
+import { FEATURES, FirebaseJSON, FirebaseRc } from '../interfaces.js';
+
+/**
+ * Builds the same test-mode starter rules `firebase init firestore` generates: anyone can read
+ * and write until a date 30 days from generation, after which all client requests are denied.
+ */
+const testModeFirestoreRules = () => {
+  const expiry = new Date();
+  expiry.setDate(expiry.getDate() + 30);
+  return `rules_version='2'
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /{document=**} {
+      // This rule allows anyone with your database reference to view, edit,
+      // and delete all data in your database. It is useful for getting
+      // started, but it is configured to expire after 30 days because it
+      // leaves your app open to attackers. At that time, all client
+      // requests to your database will be denied.
+      //
+      // Make sure to write security rules for your app before that time, or
+      // else all client requests to your database will be denied until you
+      // update your rules.
+      allow read, write: if request.time < timestamp.date(${expiry.getFullYear()}, ${expiry.getMonth() + 1}, ${expiry.getDate()});
+    }
+  }
+}
+`;
+};
+
+/**
+ * Records the selected Firebase project as the workspace's default in `.firebaserc`, so
+ * firebase-tools commands the user runs after setup completes don't prompt for (or fail without)
+ * a project. Merges into an existing file — only `projects.default` is set; targets and other
+ * aliases are preserved. Written to the real filesystem (not the schematic Tree) because
+ * `firebaseTools.init` writes `.firebaserc` on disk during the same `ng add` run — a Tree-staged
+ * copy would collide with it when the schematic commits; call this after the last
+ * `firebaseTools.init` call for that reason.
+ */
+export const setDefaultProjectInFirebaseRc = (projectRoot: string, projectId: string) => {
+  const path = join(projectRoot, '.firebaserc');
+  let rc: FirebaseRc = {};
+  if (existsSync(path)) {
+    try {
+      rc = JSON.parse(readFileSync(path).toString());
+    } catch (e) {
+      throw new SchematicsException(`Error when parsing ${path}: ${e.message}`);
+    }
+  }
+  rc.projects = { ...rc.projects, default: projectId };
+  writeFileSync(path, stringifyFormatted(rc));
+};
+
+/**
+ * When Firestore is selected, generates `firestore.rules` (test mode, with a logged warning
+ * about the 30-day expiry) and `firestore.indexes.json`. Existing files are never overwritten —
+ * a later `firebase deploy` would replace rules already deployed from elsewhere. A workspace
+ * whose firebase.json already has a `firestore` section is left entirely untouched: its section
+ * may point at differently-named files, and creating the default-named ones would only add
+ * orphans nothing references.
+ */
+export const createFirestoreStarterFiles = (
+  host: Tree,
+  context: SchematicContext,
+  features: FEATURES[],
+  firebaseJsonConfig?: FirebaseJSON,
+) => {
+  if (!features.includes(FEATURES.Firestore)) { return; }
+  if (firebaseJsonConfig?.firestore) {
+    context.logger.info('firebase.json already has a firestore section — leaving its rules and indexes untouched.');
+    return;
+  }
+  if (host.exists('/firestore.rules')) {
+    context.logger.info('firestore.rules already exists — leaving it untouched.');
+  } else {
+    host.create('/firestore.rules', testModeFirestoreRules());
+    context.logger.warn(
+      'Generated firestore.rules in test mode: anyone can read and write your database until the rules expire in 30 days. ' +
+      'Write real security rules before then — https://firebase.google.com/docs/rules'
+    );
+  }
+  if (!host.exists('/firestore.indexes.json')) {
+    // Must exist once firebase.json references it — `firebase deploy` errors on a missing indexes file.
+    host.create('/firestore.indexes.json', stringifyFormatted({ indexes: [], fieldOverrides: [] }));
+  }
+};
+
+/**
+ * When Firestore is selected, points the `firestore` section of `firebase.json` at the starter
+ * files so `firebase deploy` includes rules and indexes. Written to the real filesystem (not the
+ * schematic Tree) because firebase-tools reads and rewrites `firebase.json` during the same
+ * `ng add` run; call this after the last `firebaseTools.init` call for that reason.
+ */
+export const addFirestoreToFirebaseJson = (
+  projectRoot: string,
+  context: SchematicContext,
+  features: FEATURES[],
+) => {
+  if (!features.includes(FEATURES.Firestore)) { return; }
+  // Re-read first: firebaseTools.init calls may have rewritten firebase.json on disk.
+  let firebaseJson: FirebaseJSON;
+  try {
+    firebaseJson = JSON.parse(readFileSync(join(projectRoot, 'firebase.json')).toString());
+  } catch (e) {
+    context.logger.warn(
+      `Could not read firebase.json to add the firestore section (${e.message}). Add ` +
+      '{ "firestore": { "rules": "firestore.rules", "indexes": "firestore.indexes.json" } } to it manually.'
+    );
+    return;
+  }
+  if (!firebaseJson.firestore) {
+    firebaseJson.firestore = { rules: 'firestore.rules', indexes: 'firestore.indexes.json' };
+    writeFileSync(join(projectRoot, 'firebase.json'), stringifyFormatted(firebaseJson));
+  }
+};

--- a/src/schematics/setup/firebaseConfigs.ts
+++ b/src/schematics/setup/firebaseConfigs.ts
@@ -62,6 +62,12 @@ export const setDefaultProjectInFirebaseRc = (projectRoot: string, projectId: st
  * whose firebase.json already has a `firestore` section is left entirely untouched: its section
  * may point at differently-named files, and creating the default-named ones would only add
  * orphans nothing references.
+ *
+ * `firebaseJsonConfig`, when passed, should be the post-init snapshot of firebase.json (read
+ * after the last `firebaseTools.init` call and before `addFirestoreToFirebaseJson` runs) — see
+ * the call site in `ngAddSetupProject` for why that order matters. Passing a stale pre-init
+ * snapshot risks staging the default-named starter files on top of files firebase-tools already
+ * wrote to disk, colliding when the Tree commits.
  */
 export const createFirestoreStarterFiles = (
   host: Tree,
@@ -101,19 +107,22 @@ export const addFirestoreToFirebaseJson = (
   features: FEATURES[],
 ) => {
   if (!features.includes(FEATURES.Firestore)) { return; }
-  // Re-read first: firebaseTools.init calls may have rewritten firebase.json on disk.
-  let firebaseJson: FirebaseJSON;
+  // firebaseTools.init calls may have rewritten firebase.json on disk, so re-read it, add the
+  // firestore section if absent, and write it back. The whole read-check-write is guarded: a
+  // failed read (missing or unparseable file), a parse that isn't a usable object (reading
+  // `.firestore` off `null`/`undefined` throws; assigning it on a non-object primitive throws
+  // too), or a failed write (disk full, permissions) all warn and leave the file for the user to
+  // finish, rather than crashing the schematic with a raw Node error.
   try {
-    firebaseJson = JSON.parse(readFileSync(join(projectRoot, 'firebase.json')).toString());
+    const firebaseJson: FirebaseJSON = JSON.parse(readFileSync(join(projectRoot, 'firebase.json')).toString());
+    if (!firebaseJson.firestore) {
+      firebaseJson.firestore = { rules: 'firestore.rules', indexes: 'firestore.indexes.json' };
+      writeFileSync(join(projectRoot, 'firebase.json'), stringifyFormatted(firebaseJson));
+    }
   } catch (e) {
     context.logger.warn(
-      `Could not read firebase.json to add the firestore section (${e.message}). Add ` +
-      '{ "firestore": { "rules": "firestore.rules", "indexes": "firestore.indexes.json" } } to it manually.'
+      `Could not update firebase.json with the firestore section (${e.message}). Check firebase.json ` +
+      'and add { "firestore": { "rules": "firestore.rules", "indexes": "firestore.indexes.json" } } manually.'
     );
-    return;
-  }
-  if (!firebaseJson.firestore) {
-    firebaseJson.firestore = { rules: 'firestore.rules', indexes: 'firestore.indexes.json' };
-    writeFileSync(join(projectRoot, 'firebase.json'), stringifyFormatted(firebaseJson));
   }
 };

--- a/src/schematics/setup/index.ts
+++ b/src/schematics/setup/index.ts
@@ -16,6 +16,11 @@ import {
   parseDataConnectConfig,
   setupTanstackDependencies,
 } from '../utils';
+import {
+  addFirestoreToFirebaseJson,
+  createFirestoreStarterFiles,
+  setDefaultProjectInFirebaseRc,
+} from './firebaseConfigs';
 import { appPrompt, featuresPrompt, projectPrompt, userPrompt } from './prompts';
 
 // FirebaseOptions keys — apps.sdkconfig responses include management-API extras that initializeApp() rejects.
@@ -84,7 +89,9 @@ export const ngAddSetupProject = (
     const [ defaultProjectName ] = getFirebaseProjectNameFromHost(host, ngProjectName);
 
     const firebaseProject = await projectPrompt(defaultProjectName, { projectRoot, account: user.email });
-    
+
+    createFirestoreStarterFiles(host, context, features, firebaseJson);
+
     let firebaseApp: FirebaseApp|undefined;
     let sdkConfig: Record<string, string>|undefined;
 
@@ -139,8 +146,13 @@ export const ngAddSetupProject = (
           setupTanstackDependencies(host, context);
           setupConfig.dataConnectConfig = dataConnectConfig;
         }
-      
+
     }
+
+    // Both write the real filesystem, after the last firebaseTools.init call — init writes
+    // .firebaserc and rewrites firebase.json on disk during the run.
+    setDefaultProjectInFirebaseRc(projectRoot, firebaseProject.projectId);
+    addFirestoreToFirebaseJson(projectRoot, context, features);
 
     return setupProject(host, context, features, setupConfig);
   }

--- a/src/schematics/setup/index.ts
+++ b/src/schematics/setup/index.ts
@@ -147,18 +147,19 @@ export const ngAddSetupProject = (
 
     }
 
-    // Re-read firebase.json after the last firebaseTools.init call — init rewrites it on disk
-    // mid-run, staging files against a stale pre-init copy risks the same Tree/disk collision
-    // .firebaserc hit earlier in this file (a Tree-staged file colliding with one firebase-tools
-    // already wrote to disk, which crashes the schematic when the Tree commits). Right now no
-    // init call adds a firestore section, so this is defensive against a future one that might.
-    const firebaseJsonAfterInit: FirebaseJSON = JSON.parse(
-      readFileSync(join(projectRoot, "firebase.json")).toString()
-    );
-    // Must run before addFirestoreToFirebaseJson below: that call is what adds the firestore
-    // section on a normal run. If it ran first, this read would see the section it just added
-    // and skip creating the files — leaving firebase.json pointing at rules/indexes files that
-    // were never created.
+    // Read after the init calls, never before — firebase-tools rewrites firebase.json on disk
+    // mid-run. A failed read isn't fatal: createFirestoreStarterFiles falls back to checking the
+    // disk for each file it would create.
+    let firebaseJsonAfterInit: FirebaseJSON | undefined;
+    try {
+      firebaseJsonAfterInit = JSON.parse(
+        readFileSync(join(projectRoot, "firebase.json")).toString()
+      );
+    } catch (e) {
+      context.logger.warn(`Could not re-read firebase.json after setup (${e.message}).`);
+    }
+    // Must run before addFirestoreToFirebaseJson: that call adds the firestore section, and if it
+    // ran first this snapshot would see it and skip creating the files it points at.
     createFirestoreStarterFiles(host, context, features, firebaseJsonAfterInit);
 
     // Both write the real filesystem, after the last firebaseTools.init call — init writes

--- a/src/schematics/setup/index.ts
+++ b/src/schematics/setup/index.ts
@@ -90,8 +90,6 @@ export const ngAddSetupProject = (
 
     const firebaseProject = await projectPrompt(defaultProjectName, { projectRoot, account: user.email });
 
-    createFirestoreStarterFiles(host, context, features, firebaseJson);
-
     let firebaseApp: FirebaseApp|undefined;
     let sdkConfig: Record<string, string>|undefined;
 
@@ -148,6 +146,20 @@ export const ngAddSetupProject = (
         }
 
     }
+
+    // Re-read firebase.json after the last firebaseTools.init call — init rewrites it on disk
+    // mid-run, staging files against a stale pre-init copy risks the same Tree/disk collision
+    // .firebaserc hit earlier in this file (a Tree-staged file colliding with one firebase-tools
+    // already wrote to disk, which crashes the schematic when the Tree commits). Right now no
+    // init call adds a firestore section, so this is defensive against a future one that might.
+    const firebaseJsonAfterInit: FirebaseJSON = JSON.parse(
+      readFileSync(join(projectRoot, "firebase.json")).toString()
+    );
+    // Must run before addFirestoreToFirebaseJson below: that call is what adds the firestore
+    // section on a normal run. If it ran first, this read would see the section it just added
+    // and skip creating the files — leaving firebase.json pointing at rules/indexes files that
+    // were never created.
+    createFirestoreStarterFiles(host, context, features, firebaseJsonAfterInit);
 
     // Both write the real filesystem, after the last firebaseTools.init call — init writes
     // .firebaserc and rewrites firebase.json on disk during the run.


### PR DESCRIPTION
Fixes #3713

`ng add @angular/fire` currently leaves the workspace un-deployable: the project selected during setup is recorded nowhere, `firebase.json` stays `{}` (#3559), and selecting Firestore produces no security rules. This PR makes the setup schematic generate the same starter files `firebase init` would:

- `.firebaserc` — records the selected project as `projects.default`, merging into an existing file (other aliases and `targets` preserved). Written to the real filesystem after the `firebaseTools.init` calls, since init writes `.firebaserc` on disk during the same run.
- `firestore.rules` — only when Firestore is selected and no rules file exists: the same test-mode starter template `firebase init firestore` uses (30-day expiry), with a warning logged at generation time. Never overwrites an existing rules file.
- `firestore.indexes.json` — an empty manifest, so a plain `firebase deploy` doesn't fail on the referenced-but-missing file.
- `firebase.json` gains the `firestore` section pointing at both files, written after the Data Connect initialization (which rewrites firebase.json on disk during the same run).

The rules and indexes files go through the schematic Tree (visible in the CREATE log, honored by `--dry-run`); `.firebaserc` and the firebase.json section are written to the real filesystem because firebase-tools reads and writes both during the same run.

Includes 14 specs (`setup/firebaseConfigs.jasmine.ts`); verified end-to-end against a real project (all four artifacts generated correctly; `firebase use` resolves without prompting).

Known limitations, not addressed here: the initial `firebase.json` `'{}'` write at the top of the flow (pre-existing) uses a raw `writeFileSync` and fires even under `--dry-run`; and because the firebase.json `firestore` section reaches disk before the Tree-staged rules/indexes files do, a failure late in the schematic can leave firebase.json referencing files that were never written. Moving firebase.json fully onto the Tree — the deeper fix for both — is a larger refactor.
