### PR TITLE
fix(core): drop vestigial @angular/platform-browser-dynamic peer

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -26,7 +26,6 @@
     "@angular/common": "^21.0.0",
     "@angular/core": "^21.0.0",
     "@angular/platform-browser": "^21.0.0",
-    "@angular/platform-browser-dynamic": "^21.0.0",
     "@angular/platform-server": "^21.0.0",
     "rxjs": "~7.8.0",
     "firebase-tools": "^14.0.0 || ^15.0.0"


### PR DESCRIPTION
`ng add @angular/fire` fails with `npm error ERESOLVE` on Angular >= 20.1 apps (#3667).

**Cause**

1. `@angular/fire` declares a required peer on `@angular/platform-browser-dynamic` (`^20.0.0` on the v20 line, `^21.0.0` on `main`).
2. Every `platform-browser-dynamic` patch release requires the exact `@angular/core` and `@angular/common` version matching its own patch (for example, `platform-browser-dynamic@20.1.7` declares `@angular/core@20.1.7`).
3. To satisfy that wide peer range, npm picks some `platform-browser-dynamic` patch, and that patch in turn requires the exact `@angular/core` and `@angular/common` version matching itself (per point 2). That required version usually differs from the `core`/`common` the app already has installed, so npm cannot satisfy both at once and the install aborts with `ERESOLVE`. The reporter's tree pulled in `platform-browser-dynamic@20.1.7`, which demanded `core@20.1.7` while their app had `core@20.1.6`; a pristine Angular 20 app hits the same conflict through `20.0.7`.

**Why removing the peer is safe**

- Nothing in the published package imports `platform-browser-dynamic`. The unpacked `@angular/fire@20.0.1` and `@21.0.0-rc.0` tarballs contain zero references outside the peer declaration itself (checked `fesm2022/*.mjs`, all `.d.ts`, and `schematics/`).
- The repository's only usage is the Karma test bootstrap (`src/test.ts`), which is supplied by the repository's root `package.json` and is unaffected.
- Apps that still bootstrap with `platformBrowserDynamic()` get the package from their own dependencies, never from this peer.
- Angular deprecated `platform-browser-dynamic` as of 20.1; the peer currently forces a deprecated package into every consumer install.

**Alternative considered:** marking the peer optional in `peerDependenciesMeta` (the pattern this manifest already uses for `firebase-tools` and `@angular/platform-server`). That would also avoid the `ERESOLVE` on npm, but it keeps advertising a dependency relationship that does not exist, and the fix would then depend on npm-specific resolver behavior. Removal fixes every package manager. There is precedent for removing unneeded peers outright (#2095).

**Verification:** built the package from this branch and installed the packed tarball into a fresh Angular 21 app: the install succeeds with no `ERESOLVE`, and `platform-browser-dynamic` is absent from the dependency tree. A control install of the currently published package into the same app pulls in the deprecated `platform-browser-dynamic@21.2.18`.

Angular 20 users get this fix through the planned 20.0.2 patch release, which cherry-picks this commit together with the already-merged config generation fix (#3707).

Refs #3667 (left open deliberately: the reporters there are on the v20 line, so the issue will be closed manually once 20.0.2 ships this fix to npm `latest`).
