### PR TITLE
fix(schematics): align the workspace firebase dependency with the supported range

### DIFF
--- a/src/schematics/add/index.ts
+++ b/src/schematics/add/index.ts
@@ -1,6 +1,6 @@
 import { SchematicContext, Tree } from '@angular-devkit/schematics';
 import { NodePackageInstallTask, RunSchematicTask } from '@angular-devkit/schematics/tasks';
-import { addDependencies, pinInstalledPrereleaseVersion } from '../common';
+import { addDependencies, alignFirebaseVersion, pinInstalledPrereleaseVersion } from '../common';
 import { DeployOptions } from '../interfaces';
 import { peerDependencies } from '../versions.json';
 
@@ -10,6 +10,7 @@ export const ngAdd = (options: DeployOptions) => (tree: Tree, context: Schematic
     peerDependencies,
     context
   );
+  alignFirebaseVersion(tree, context);
   pinInstalledPrereleaseVersion(tree, context);
   const npmInstallTaskId = context.addTask(new NodePackageInstallTask());
   context.addTask(new RunSchematicTask('ng-add-setup-project', options), [npmInstallTaskId]);

--- a/src/schematics/common.jasmine.ts
+++ b/src/schematics/common.jasmine.ts
@@ -1,6 +1,7 @@
+import { readFileSync } from 'fs';
 import { logging } from '@angular-devkit/core';
 import { HostTree, SchematicContext } from '@angular-devkit/schematics';
-import { pinInstalledPrereleaseVersion } from './common.js';
+import { alignFirebaseVersion, firebaseVersionRange, pinInstalledPrereleaseVersion } from './common.js';
 import 'jasmine';
 
 const context = { logger: new logging.Logger('test') } as unknown as SchematicContext;
@@ -112,6 +113,114 @@ describe('pinInstalledPrereleaseVersion', () => {
     pinInstalledPrereleaseVersion(tree, context, '21.0.0-rc.0');
     expect(dependenciesIn(tree)['@angular/fire']).toBe('21.0.0-rc.0');
     expect(sectionIn(tree, 'devDependencies')['@angular/fire']).toBe('^21.0.0-rc.0');
+  });
+
+});
+
+const treeWithFirebase = (firebaseVersion?: string, section = 'dependencies') => {
+  const tree = new HostTree();
+  const packageContents: Record<string, unknown> = { name: 'test-app' };
+  if (firebaseVersion !== undefined) {
+    packageContents[section] = { firebase: firebaseVersion };
+  }
+  tree.create('package.json', JSON.stringify(packageContents, null, 2));
+  return tree;
+};
+
+describe('alignFirebaseVersion', () => {
+
+  it('rewrites a previous-major range', () => {
+    const tree = treeWithFirebase('^11.0.0');
+    expect(alignFirebaseVersion(tree, context)).toBeTrue();
+    expect(dependenciesIn(tree).firebase).toBe(firebaseVersionRange);
+  });
+
+  it('rewrites a same-major range that still allows versions below the required floor', () => {
+    const tree = treeWithFirebase('^12.0.0');
+    expect(alignFirebaseVersion(tree, context)).toBeTrue();
+    expect(dependenciesIn(tree).firebase).toBe(firebaseVersionRange);
+  });
+
+  it('rewrites a wide range that a stale lockfile can hold below the floor', () => {
+    const tree = treeWithFirebase('>=11');
+    expect(alignFirebaseVersion(tree, context)).toBeTrue();
+    expect(dependenciesIn(tree).firebase).toBe(firebaseVersionRange);
+  });
+
+  it('leaves a compatible range untouched', () => {
+    const tree = treeWithFirebase('^12.6.0');
+    expect(alignFirebaseVersion(tree, context)).toBeFalse();
+    expect(dependenciesIn(tree).firebase).toBe('^12.6.0');
+  });
+
+  it('adds firebase when the workspace has none', () => {
+    const tree = treeWithFirebase(undefined);
+    expect(alignFirebaseVersion(tree, context)).toBeTrue();
+    expect(dependenciesIn(tree).firebase).toBe(firebaseVersionRange);
+  });
+
+  it('aligns firebase in devDependencies without duplicating it into dependencies', () => {
+    const tree = treeWithFirebase('^11.0.0', 'devDependencies');
+    expect(alignFirebaseVersion(tree, context)).toBeTrue();
+    expect(sectionIn(tree, 'devDependencies').firebase).toBe(firebaseVersionRange);
+    expect(sectionIn(tree, 'dependencies')).toBeUndefined();
+  });
+
+  it('warns about a non-semver specifier and leaves it as-is', () => {
+    const warnSpy = spyOn(context.logger, 'warn');
+    const tree = treeWithFirebase('latest');
+    expect(alignFirebaseVersion(tree, context)).toBeFalse();
+    expect(dependenciesIn(tree).firebase).toBe('latest');
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('warns about a workspace specifier and leaves it as-is', () => {
+    const warnSpy = spyOn(context.logger, 'warn');
+    const tree = treeWithFirebase('workspace:*');
+    expect(alignFirebaseVersion(tree, context)).toBeFalse();
+    expect(dependenciesIn(tree).firebase).toBe('workspace:*');
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('rewrites stale entries in both sections when firebase appears twice', () => {
+    const tree = new HostTree();
+    tree.create('package.json', JSON.stringify({
+      name: 'test-app',
+      dependencies: { firebase: '^11.0.0' },
+      devDependencies: { firebase: '~11.9.0' },
+    }, null, 2));
+    expect(alignFirebaseVersion(tree, context)).toBeTrue();
+    expect(dependenciesIn(tree).firebase).toBe(firebaseVersionRange);
+    expect(sectionIn(tree, 'devDependencies').firebase).toBe(firebaseVersionRange);
+  });
+
+  it('rewrites only the stale section when the other is already compatible', () => {
+    const tree = new HostTree();
+    tree.create('package.json', JSON.stringify({
+      name: 'test-app',
+      dependencies: { firebase: '^12.6.0' },
+      devDependencies: { firebase: '^11.0.0' },
+    }, null, 2));
+    expect(alignFirebaseVersion(tree, context)).toBeTrue();
+    expect(dependenciesIn(tree).firebase).toBe('^12.6.0');
+    expect(sectionIn(tree, 'devDependencies').firebase).toBe(firebaseVersionRange);
+  });
+
+  it('matches the firebase range the library actually ships with', () => {
+    const libraryManifest = JSON.parse(readFileSync('src/package.json', 'utf8'));
+    expect(libraryManifest.dependencies.firebase).toBe(firebaseVersionRange);
+  });
+
+  it('is a no-op when run a second time', () => {
+    const tree = treeWithFirebase('^11.0.0');
+    expect(alignFirebaseVersion(tree, context)).toBeTrue();
+    expect(alignFirebaseVersion(tree, context)).toBeFalse();
+    expect(dependenciesIn(tree).firebase).toBe(firebaseVersionRange);
+  });
+
+  it('throws when package.json is absent', () => {
+    const tree = new HostTree();
+    expect(() => alignFirebaseVersion(tree, context)).toThrow();
   });
 
 });

--- a/src/schematics/common.ts
+++ b/src/schematics/common.ts
@@ -3,6 +3,7 @@ import {
   intersects as semverIntersects,
   prerelease as semverPrerelease,
   satisfies as semverSatisfies,
+  subset as semverSubset,
   valid as semverValid,
 } from 'semver';
 import { FirebaseHostingSite } from './interfaces';
@@ -69,6 +70,74 @@ export const addDependencies = (
   });
 
   overwriteIfExists(host, 'package.json', stringifyFormatted(packageJson));
+};
+
+// Must stay identical to `dependencies.firebase` in `src/package.json`: if the two drift, the
+// alignment below can pin workspaces outside the range the library actually installs against,
+// re-creating the duplicate-SDK trees it exists to prevent.
+export const firebaseVersionRange = '^12.4.0';
+
+/**
+ * Aligns the workspace's `firebase` entry with the range `@angular/fire` requires.
+ *
+ * `@angular/fire` bundles its own `firebase` dependency, so a workspace pinned to an older
+ * major never conflicts at install time; npm silently nests a second SDK copy under
+ * `@angular/fire`, and the two copies reject each other's objects at runtime (#3684, #3681,
+ * #3682). Rewriting the workspace's range before the install runs is the only point where
+ * that class of breakage can be headed off.
+ *
+ * Returns whether `package.json` was modified, so callers can skip scheduling an install
+ * when nothing changed (`ng update` re-runs the v21 migration on rc-to-stable updates).
+ */
+export const alignFirebaseVersion = (
+  host: Tree,
+  context: SchematicContext,
+): boolean => {
+  if (!host.exists('package.json')) {
+    throw new SchematicsException('Could not locate package.json');
+  }
+  const packageJson = safeReadJSON('package.json', host);
+
+  const sectionsWithFirebase = ['dependencies', 'devDependencies'].filter(
+    section => typeof packageJson[section]?.firebase === 'string',
+  );
+
+  if (sectionsWithFirebase.length === 0) {
+    packageJson.dependencies ??= {};
+    packageJson.dependencies.firebase = firebaseVersionRange;
+    context.logger.info(`Added firebase ${firebaseVersionRange} to your package.json.`);
+    overwriteIfExists(host, 'package.json', stringifyFormatted(packageJson));
+    return true;
+  }
+
+  let changed = false;
+  for (const section of sectionsWithFirebase) {
+    const declaredFirebaseVersion = packageJson[section].firebase;
+    let alreadyCompatible: boolean;
+    try {
+      alreadyCompatible = semverSubset(declaredFirebaseVersion, firebaseVersionRange);
+    } catch (_) {
+      context.logger.warn(
+        `⚠️ The firebase version in your package.json (${declaredFirebaseVersion}) is not a semver ` +
+        `range, so it was left as-is; make sure it resolves inside ${firebaseVersionRange}, the ` +
+        'range @angular/fire requires; a version outside it can leave the install with two copies of the firebase SDK.'
+      );
+      continue;
+    }
+    if (alreadyCompatible) { continue; }
+    packageJson[section].firebase = firebaseVersionRange;
+    context.logger.info(
+      `Updated the firebase version in your package.json from ${declaredFirebaseVersion} to ` +
+      `${firebaseVersionRange}, the range @angular/fire requires; a workspace range outside it ` +
+      'can leave the install with a second copy of the firebase SDK, which fails at runtime.'
+    );
+    changed = true;
+  }
+
+  if (changed) {
+    overwriteIfExists(host, 'package.json', stringifyFormatted(packageJson));
+  }
+  return changed;
 };
 
 // The build writes the published version over this placeholder in the compiled schematics

--- a/src/schematics/migration.json
+++ b/src/schematics/migration.json
@@ -6,6 +6,11 @@
             "description": "Update @angular/fire to v7",
             "factory": "./update/v7#ngUpdate"
         },
+        "migration-v21": {
+            "version": "21.0.0",
+            "description": "Align the workspace's firebase dependency with the range @angular/fire 21 requires, so the install cannot contain two copies of the firebase SDK",
+            "factory": "./update/v21#ngUpdate"
+        },
         "ng-post-upgate": {
             "description": "Print out results after ng-update",
             "factory": "./update#ngPostUpdate",

--- a/src/schematics/tsconfig.json
+++ b/src/schematics/tsconfig.json
@@ -28,5 +28,6 @@
         "add/index.ts",
         "setup/index.ts",
         "update/v7/index.ts",
+        "update/v21/index.ts",
     ]
 }

--- a/src/schematics/update/v21/index.jasmine.ts
+++ b/src/schematics/update/v21/index.jasmine.ts
@@ -1,0 +1,43 @@
+import { logging } from '@angular-devkit/core';
+import { HostTree, SchematicContext } from '@angular-devkit/schematics';
+import { firebaseVersionRange } from '../../common.js';
+import { ngUpdate } from './index.js';
+import 'jasmine';
+
+const contextWithTaskSpy = () => {
+  const addTask = jasmine.createSpy('addTask');
+  const context = {
+    logger: new logging.Logger('test'),
+    addTask,
+  } as unknown as SchematicContext;
+  return { context, addTask };
+};
+
+const treeWithFirebase = (firebaseVersion?: string) => {
+  const tree = new HostTree();
+  tree.create('package.json', JSON.stringify({
+    name: 'test-app',
+    dependencies: firebaseVersion === undefined ? {} : { firebase: firebaseVersion },
+  }, null, 2));
+  return tree;
+};
+
+describe('migration-v21 ngUpdate', () => {
+
+  it('aligns a stale firebase range and schedules an install', () => {
+    const { context, addTask } = contextWithTaskSpy();
+    const tree = treeWithFirebase('^11.0.0');
+    ngUpdate()(tree, context);
+    const written = JSON.parse(tree.readText('package.json'));
+    expect(written.dependencies.firebase).toBe(firebaseVersionRange);
+    expect(addTask).toHaveBeenCalledTimes(1);
+  });
+
+  it('schedules nothing when the workspace is already aligned', () => {
+    const { context, addTask } = contextWithTaskSpy();
+    const tree = treeWithFirebase(firebaseVersionRange);
+    ngUpdate()(tree, context);
+    expect(addTask).not.toHaveBeenCalled();
+  });
+
+});

--- a/src/schematics/update/v21/index.ts
+++ b/src/schematics/update/v21/index.ts
@@ -1,0 +1,17 @@
+import { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+// The explicit index.js subpath keeps this importable from the ESM jasmine run; the bare
+// /tasks directory specifier only resolves under CommonJS.
+import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks/index.js';
+import { alignFirebaseVersion } from '../../common.js';
+
+// ng update re-runs this migration on rc-to-stable transitions (the CLI clamps the migration
+// range's upper bound to the release version), so it must stay a no-op when nothing changes.
+export const ngUpdate = (): Rule => (
+  host: Tree,
+  context: SchematicContext
+) => {
+  if (alignFirebaseVersion(host, context)) {
+    context.addTask(new NodePackageInstallTask());
+  }
+  return host;
+};

--- a/tools/build.ts
+++ b/tools/build.ts
@@ -322,6 +322,7 @@ async function compileSchematics() {
       src('schematics', "add", "index.ts"),
       src('schematics', "setup", "index.ts"),
       src('schematics', "update", "v7", "index.ts"),
+      src('schematics', "update", "v21", "index.ts"),
     ],
     format: "cjs",
     // turns out schematics don't support ESM, need to use webpack or shim these


### PR DESCRIPTION
### Checklist

   - Issue number for this PR: #3684 (also #3681 and #3682; all three share the root cause this PR addresses. Referenced with `Refs` rather than `Fixes`: no published build carries the change until the next release is cut or a canary is published, so the issues should close when reporters can actually install the fix.)
   - Docs included?: No. The migration and `ng add` print a one-line explanation whenever they change anything, and the v21 upgrade documentation is tracked with the release notes.
   - Test units included?: Yes (15 new specs: the alignment helper's range handling, warning behavior, both-dependency-sections handling, idempotency, a constant-sync check against `src/package.json`, and the migration's install-task behavior).
   - In a clean directory, `yarn install`, `yarn test` run successfully? Yes; `npm run build` and the node test suites run green locally (55 specs), and the migration was verified end-to-end against a packed build (below).

### Description

Upgrading an app to `@angular/fire` 21 while its own `package.json` still requests `firebase@11` produces an install with two copies of the firebase SDK: npm keeps 11 at the root and nests 12 under `@angular/fire`. No install-time error fires, and the two copies reject each other's objects at runtime. #3684, #3681, and #3682 are all this one failure (analysis and reproductions in those threads).

This PR makes the schematics keep the workspace's `firebase` entry aligned with the range the library requires:

- a shared `alignFirebaseVersion` helper and `firebaseVersionRange` constant in `src/schematics/common.ts`;
- `ng add` writes the entry when missing and realigns an incompatible one before its install task runs;
- a new `migration-v21` runs the same alignment during `ng update @angular/fire`, scheduling an install only when it changed something (the CLI re-runs the migration on rc-to-stable updates, so the no-op path matters).

Behavior details:

- A range is rewritten only when it is not entirely inside `^12.4.0` (`semver.subset`); `intersects` would keep ranges like `^12.0.0` or `>=11` that a stale lockfile still resolves below the required floor.
- Non-semver specifiers (dist-tags, `workspace:`, `file:`, git URLs) are never rewritten; the user gets a warning explaining the risk instead.
- `firebaseVersionRange` intentionally duplicates `dependencies.firebase` from `src/package.json` instead of being injected at build time: the build's version-injection machinery (`versions.json`) is under discussion in #3715, so the constant is the minimal bridge that machinery can later supersede. A spec reads `src/package.json` and fails the suite if the two values ever drift.

Verified end-to-end against a packed build. A fixture app with `firebase@11.8.0` installed next to this package (the exact broken tree from the linked issues), then `ng update @angular/fire --migrate-only --from=20.0.1`:

```
❯ Align the workspace's firebase dependency with the range @angular/fire 21 requires,
  so the install cannot contain two copies of the firebase SDK.
    Updated the firebase version in your package.json from ^11.8.0 to ^12.4.0, the range
    @angular/fire requires; a workspace range outside it can leave the install with a
    second copy of the firebase SDK, which fails at runtime.
UPDATE package.json (400 bytes)
✔ Packages installed successfully.
```

`npm ls firebase` afterwards shows a single `firebase@12.16.0`, and a second run reports "Migration completed (No changes made)".


### Note for reviewers

`src/schematics/update/v21/index.ts` uses explicit `.js`-suffixed relative imports where `v7/index.ts` does not. This is intentional: the dedicated jasmine spec imports the migration directly under ESM, which requires the suffix. Please do not "fix" it back to match `v7`.
