### PR TITLE
fix(core): raise the rxfire floor to ^6.2.0 for its firebase 12 peers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@angular/fire",
-  "version": "21.0.0-next.0",
+  "version": "21.0.0-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@angular/fire",
-      "version": "21.0.0-next.0",
+      "version": "21.0.0-rc.0",
       "license": "MIT",
       "dependencies": {
         "@angular-devkit/architect": "~0.2100.0",
@@ -29,7 +29,7 @@
         "jsonc-parser": "^3.0.0",
         "open": "^7.0.3 || ^8.0.0",
         "ora": "^5.3.0",
-        "rxfire": "^6.1.0",
+        "rxfire": "^6.2.0",
         "rxjs": "~7.8.0",
         "semver": "^7.1.3",
         "triple-beam": "^1.3.0",
@@ -22041,12 +22041,12 @@
       }
     },
     "node_modules/rxfire": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/rxfire/-/rxfire-6.1.0.tgz",
-      "integrity": "sha512-NezdjeY32VZcCuGO0bbb8H8seBsJSCaWdUwGsHNzUcAOHR0VGpzgPtzjuuLXr8R/iemkqSzbx/ioS7VwV43ynA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/rxfire/-/rxfire-6.2.0.tgz",
+      "integrity": "sha512-XSRdYjV6rZJUbUL2IpTqLtgnhNHDp9j2KSHZW04R+/ODKm8Ir2ag8I+kVZCq6j1NCclB4JMx60sgSDWcvDYR3g==",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "firebase": "^9.0.0 || ^10.0.0 || ^11.0.0",
+        "firebase": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0",
         "rxjs": "^6.0.0 || ^7.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "jsonc-parser": "^3.0.0",
     "open": "^7.0.3 || ^8.0.0",
     "ora": "^5.3.0",
-    "rxfire": "^6.1.0",
+    "rxfire": "^6.2.0",
     "rxjs": "~7.8.0",
     "semver": "^7.1.3",
     "triple-beam": "^1.3.0",
@@ -119,11 +119,6 @@
     "tslint": "~6.1.0",
     "typescript": ">=5.9 <6.0",
     "yaml": "^2.7.0"
-  },
-  "overrides": {
-    "rxfire": {
-      "firebase": "^12.4.0"
-    }
   },
   "typings": "index.d.ts"
 }

--- a/src/package.json
+++ b/src/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "firebase": "^12.4.0",
-    "rxfire": "^6.1.0",
+    "rxfire": "^6.2.0",
     "@angular-devkit/schematics": "^21.0.0",
     "@schematics/angular": "^21.0.0",
     "tslib": "^2.3.0"


### PR DESCRIPTION
rxfire 6.2.0 shipped to npm `latest` on July 22, 2026 with firebase 12 in its peer range (FirebaseExtended/rxfire#152). This PR raises our dependency floor to require it.

### Background

- rxfire 6.1.0 accepts firebase `^9 || ^10 || ^11` as peers. `@angular/fire` on `main` depends on `firebase ^12.4.0`, so a tree holding rxfire 6.1.0 gets a second firebase 11 installed next to firebase 12 (or, at best, an invalid-peer marker).
- Two installed SDK copies fail each other's instance checks at runtime; the first Firestore read throws `Type does not match the expected instance. Did you pass a reference from a different Firestore SDK?`.
- rxfire 6.2.0 widens the peer range to `^9 || ^10 || ^11 || ^12` and contains no other runtime change (the only other commit between 6.1.0 and 6.2.0 is CI-only).

### What this changes

- `src/package.json`: `rxfire` `^6.1.0` to `^6.2.0` (the range the published package ships).
- root `package.json`: the same bump, and removes the `overrides` block that forced rxfire's firebase peer to `^12.4.0` in this repo's own install tree; rxfire 6.2.0 makes it unnecessary.
- `package-lock.json`: rxfire moves to 6.2.0; npm also synced the lockfile's stale root version `21.0.0-next.0` to `21.0.0-rc.0`, matching `package.json`.

### Why raise the floor when ^6.1.0 already resolves to 6.2.0

Fresh installs are unaffected: a clean project installing `@angular/fire@21.0.0-rc.0` today already resolves rxfire 6.2.0 and a single firebase (verified). The floor is for upgrades: a lockfile that pins rxfire 6.1.0 satisfies `^6.1.0`, survives an `@angular/fire` upgrade, and rxfire 6.1.0's peer set then re-creates the duplicate firebase 11. With `^6.2.0` the upgrade is forced onto the fixed release.

### What this does not fix

An app whose own `firebase` dependency stays on 11.x still ends up with two SDK copies: rxfire binds the root firebase 11 while `@angular/fire` nests firebase 12. That is the mechanism behind #3684, #3681, and #3682, and the fix there is upgrading the app's `firebase` to `^12` together with `@angular/fire`; a schematics follow-up and the release notes will cover that path. Refs #3666.

### Verification

- Clean-project install of `21.0.0-rc.0`: resolves rxfire 6.2.0, one `firebase@12.16.0` (rxfire's copy deduped), one `@firebase/firestore`.
- Repo tree after the change: rxfire 6.2.0, single firebase, no nested copy under rxfire.
- `npm run build`: the packed tarball's `package.json` carries `rxfire: ^6.2.0`.


### Related

This raises the rxfire floor so fresh installs and lockfile-pinned upgraders resolve the fixed rxfire. It does not help an app whose own `firebase` dependency stays on 11.x; that path is what #3722 addresses (aligns the workspace `firebase` to `^12` on `ng update`, and validates it on `ng add`). #3722 carries `Refs #3684/#3681/#3682`, so the full remediation is trackable across the two PRs.
