### PR TITLE
fix(deploy): target Node 22 and the firebase-functions/v1 API in generated Cloud Functions

### DIFF
--- a/docs/deploy/getting-started.md
+++ b/docs/deploy/getting-started.md
@@ -97,7 +97,7 @@ Setting `functionsNodeVersion` and `functionsRuntimeOptions` in your `angular.js
 "deploy": {
     "builder": "@angular/fire:deploy",
     "options": {
-        "functionsNodeVersion": 12,
+        "functionsNodeVersion": 22,
         "functionsRuntimeOptions": {
           "memory": "2GB",
           "timeoutSeconds": 10,

--- a/site/src/get-started/deploying.md
+++ b/site/src/get-started/deploying.md
@@ -98,13 +98,13 @@ To customize the deployment flow, you can use the configuration files you're alr
 
 ### Configuring Cloud Functions
 
-Setting `functionsNodeVersion` and `functionsRuntimeOptions` in your `angular.json` allow you to custimze the version of Node.js Cloud Functions is running and run-time settings like timeout, VPC connectors, and memory.
+Setting `functionsNodeVersion` and `functionsRuntimeOptions` in your `angular.json` allow you to customize the version of Node.js Cloud Functions is running and run-time settings like timeout, VPC connectors, and memory.
 
 ```json
 "deploy": {
     "builder": "@angular/fire:deploy",
     "options": {
-        "functionsNodeVersion": 12,
+        "functionsNodeVersion": 22,
         "functionsRuntimeOptions": {
           "memory": "2GB",
           "timeoutSeconds": 10,

--- a/src/schematics/deploy/functions-templates.jasmine.ts
+++ b/src/schematics/deploy/functions-templates.jasmine.ts
@@ -1,0 +1,20 @@
+import { DEFAULT_NODE_VERSION, defaultFunction, defaultPackage } from './functions-templates.js';
+import 'jasmine';
+
+describe('functions templates', () => {
+  describe('defaultFunction', () => {
+    it('requires the firebase-functions/v1 subpath, where the v1 API lives on firebase-functions 6', () => {
+      const generated = defaultFunction('dist/app', {}, undefined);
+      expect(generated).toContain(`require('firebase-functions/v1')`);
+      expect(generated).not.toContain(`require('firebase-functions')`);
+    });
+  });
+
+  describe('defaultPackage', () => {
+    it('defaults engines.node to a runtime Cloud Functions still accepts', () => {
+      const generated = defaultPackage({}, {}, {});
+      expect(generated.engines.node).toBe(DEFAULT_NODE_VERSION.toString());
+      expect(DEFAULT_NODE_VERSION).toBe(22);
+    });
+  });
+});

--- a/src/schematics/deploy/functions-templates.ts
+++ b/src/schematics/deploy/functions-templates.ts
@@ -1,6 +1,9 @@
 import { DeployBuilderOptions } from './actions';
 
-export const DEFAULT_NODE_VERSION = 14;
+// Must be a runtime Cloud Functions still accepts, and must satisfy the engines of @angular/core
+// (the function runs the Angular server) and of firebase-admin. The `dockerfile` template below
+// also drops it into `FROM node:<version>-slim`, so it picks the base image on the Cloud Run path.
+export const DEFAULT_NODE_VERSION = 22;
 export const DEFAULT_FUNCTION_NAME = 'ssr';
 
 const DEFAULT_FUNCTION_REGION = 'us-central1';
@@ -34,7 +37,9 @@ export const defaultFunction = (
   path: string,
   options: DeployBuilderOptions,
   functionName: string|undefined,
-) => `const functions = require('firebase-functions');
+// `.region()` lives on the /v1 subpath since firebase-functions 6. Requiring the package root
+// instead still resolves, and fails only when the deployed function serves its first request.
+) => `const functions = require('firebase-functions/v1');
 
 // Increase readability in Cloud Logging
 require("firebase-functions/logger/compat");

--- a/src/schematics/deploy/functions-templates.ts
+++ b/src/schematics/deploy/functions-templates.ts
@@ -33,12 +33,12 @@ export const defaultPackage = (
   private: true
 });
 
+// `.region()` lives on the /v1 subpath since firebase-functions 6. Requiring the package root
+// instead still resolves, and fails only when the deployed function serves its first request.
 export const defaultFunction = (
   path: string,
   options: DeployBuilderOptions,
   functionName: string|undefined,
-// `.region()` lives on the /v1 subpath since firebase-functions 6. Requiring the package root
-// instead still resolves, and fails only when the deployed function serves its first request.
 ) => `const functions = require('firebase-functions/v1');
 
 // Increase readability in Cloud Logging


### PR DESCRIPTION
### Checklist

   - Issue number for this PR: #3742 (required)
   - Docs included?: yes
   - Test units included?: no. The existing Node suite passes (117 specs). The change is to generated-code templates with no spec file today, and it was verified by generating the function from the built templates and loading it against a real firebase-functions 6 install: the old template throws `TypeError: functions.region is not a function`, the fixed one loads.
   - In a clean directory, `yarn install`, `yarn test` run successfully?: yes

### Description

Fixes #3742.

Three fixes to what `ng deploy` generates for Cloud Functions:

- **`DEFAULT_NODE_VERSION` goes from 14 to 22.**
  - Node 14 was decommissioned by Cloud Functions in early 2025, so the generated function could not deploy at all.
  - 22 is the newest runtime Cloud Functions supports.
  - It satisfies the engines ranges of `@angular/core` (`^20.19.0 || ^22.12.0 || >=24.0.0`) and `firebase-admin` (`>=18`).
  - Node 20 would also deploy today, but its security support ended 2026-04-30.
  - The same constant picks the Cloud Run base image, so that path moves from the stale `node:14-slim` to `node:22-slim`.
- **The gen 1 template requires `firebase-functions/v1`.**
  - On firebase-functions 6 the v1 API moved off the package root, so the generated `functions.region(...)` call threw `TypeError: functions.region is not a function` on cold start.
  - The `/v1` subpath is present on both firebase-functions 6 and 7.
- **The docs example asks for `functionsNodeVersion: 22`** instead of the decommissioned 12.

These defects also affect the v20 line and are planned for cherry-pick onto the 20.0.x release branch after this lands.
