### PR TITLE
chore: bump version to 21.0.0-rc.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@angular/fire",
-  "version": "21.0.0-rc.0",
+  "version": "21.0.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@angular/fire",
-      "version": "21.0.0-rc.0",
+      "version": "21.0.0-rc.1",
       "license": "MIT",
       "dependencies": {
         "@angular-devkit/architect": "~0.2100.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular/fire",
-  "version": "21.0.0-rc.0",
+  "version": "21.0.0-rc.1",
   "description": "Angular + Firebase = ❤️",
   "publishConfig": {
     "registry": "https://wombat-dressing-room.appspot.com",

--- a/sample/README.md
+++ b/sample/README.md
@@ -4,7 +4,7 @@ This project was generated using [Angular CLI](https://github.com/angular/angula
 
 ## AngularFire tarball
 
-The sample consumes the library as `file:../angular-fire-21.0.0-rc.0.tgz`. Produce that file from the repository root before installing here:
+The sample consumes the library as `file:../angular-fire-21.0.0-rc.1.tgz`. Produce that file from the repository root before installing here:
 
 ```bash
 npm ci
@@ -16,7 +16,7 @@ The root build ends with `npm pack ./dist/packages-dist`, which writes `angular-
 Then, from this `sample/` folder, install the dependencies by naming the tarball explicitly:
 
 ```bash
-npm install ../angular-fire-21.0.0-rc.0.tgz
+npm install ../angular-fire-21.0.0-rc.1.tgz
 ```
 
 A plain `npm install` is not reliable here. `package-lock.json` records the integrity hash of the tarball built by whoever committed the lockfile, and a tarball you build yourself can hash differently. With a cold npm cache the install then fails with an `EINTEGRITY` error. With a warm cache that holds the recorded hash, npm installs the stale cached copy and exits successfully, so you would be testing a library you did not build. Naming the tarball installs the file on disk and rewrites the recorded hash in your local `package-lock.json`. Leave that lockfile change uncommitted.

--- a/sample/package.json
+++ b/sample/package.json
@@ -14,7 +14,7 @@
     "@angular/common": "^21.0.0",
     "@angular/compiler": "^21.0.0",
     "@angular/core": "^21.0.0",
-    "@angular/fire": "file:../angular-fire-21.0.0-rc.0.tgz",
+    "@angular/fire": "file:../angular-fire-21.0.0-rc.1.tgz",
     "@angular/forms": "^21.0.0",
     "@angular/platform-browser": "^21.0.0",
     "@angular/platform-server": "^21.0.0",


### PR DESCRIPTION
### Checklist

   - Issue number for this PR: none, release mechanics for the 21.0.0-rc.1 cut
   - Docs included?: only the sample README's install example, which names the tarball version
   - Test units included?: no, version literals only
   - In a clean directory, `yarn install`, `yarn test` run successfully?: not applicable, no source changed

### Description

Bumps the root `package.json` version literal to `21.0.0-rc.1` ahead of the release tag. The publish workflow reads this literal to name the npm release.

The sample consumes the library as `file:../angular-fire-<version>.tgz`, so its `package.json` dependency path and the install example in its README are bumped to the same version in this change.
