### PR TITLE
build: require firebase ^12.18.0 and wrap the functions it adds

### DIFF
--- a/docs/messaging.md
+++ b/docs/messaging.md
@@ -6,7 +6,7 @@
 
 # Cloud Messaging
 
-Firebase FCM allows you to register devices with unique FCM tokens, that you can later programtically send notifications to using Firebase Cloud Functions. It is up to the application to update these tokens in Firebase if you want to use them in other layers of your application, i.e send a notification to all administrators, etc. In that case, you would likely want to store your fcm tokens on your user collection, or a sub collection or another collection with different permissions.
+Firebase Cloud Messaging (FCM) allows you to register devices with unique FCM tokens, that you can later programatically send notifications to using Firebase Cloud Functions. It is up to the application to update these tokens in Firebase if you want to use them in other layers of your application, i.e send a notification to all administrators, etc. In that case, you would likely want to store your fcm tokens on your user collection, or a sub collection or another collection with different permissions.
 
 ## Dependency Injection
 
@@ -47,7 +47,7 @@ export class AppComponent {
 
 # Create a Firebase Messaging Service Worker 
 
-There are two parts to Firebase Messaging, a Service Worker and the DOM API. Angular Fire Messaging allows you to request permission, get tokens, delete tokens, and subscribe to messages on the DOM side. To register to receive notifications you need to set up the Service Worker. [The official Firebase documentation for setting up the details exactly how to do that](https://firebase.google.com/docs/cloud-messaging/js/client).
+There are two parts to Firebase Messaging, a Service Worker and the DOM API. Angular Fire Messaging allows you to request permission, register this app instance, observe when it is registered or unregistered, and subscribe to messages on the DOM side. To register to receive notifications you need to set up the Service Worker. [The official Firebase documentation for setting up the details exactly how to do that](https://firebase.google.com/docs/cloud-messaging/js/client).
 
 #### Create your firebase-messaging-sw.js file in your src/assets folder
 
@@ -55,7 +55,7 @@ There are two parts to Firebase Messaging, a Service Worker and the DOM API. Ang
 
 It may be wise to use file replacements or environments here for different environments
 
-```
+```js
 /* Replace <firebase-version> with the firebase version in your package.json. The service
  * worker and your application have to load the same version. */
 
@@ -74,54 +74,81 @@ const firebaseApp = initializeApp({
 const messaging = getMessaging(firebaseApp);
 ```
 
+# Registering this app instance
+
+Firebase deprecated `getToken` and `deleteToken` in firebase 12.18 and will remove them. Use `register` with `onRegistered` in place of `getToken`, and `unregister` with `onUnregistered` in place of `deleteToken`. [Firebase's client guide](https://firebase.google.com/docs/cloud-messaging/js/client) describes the model and asks that you not mix the two sets.
+
+Three things to know before you copy the example below:
+
+- `onRegistered` has to be listening before `register` runs, which is why the example subscribes first. Otherwise `register` throws `No onRegistered callback handler was provided or registered.`
+- **Ask for notification permission yourself before calling `register`,** as the example does. Otherwise `register` asks for you from inside a call AngularFire wraps, which holds the client app unstable until the dialog is dismissed.
+  - That delays Angular event replay and clearing the server-rendered DOM, and logs a development-only warning after ten seconds. Asking first avoids all of it.
+  - This behavior may change in a future release.
+- The identifier reaches you through a callback rather than as a return value, and again whenever it changes, so store it from inside the callback rather than once at startup.
+
 # Example messaging service
 
-```
-import { Injectable } from "@angular/core";
-import { Messaging, MessagePayload, getToken, onMessage, deleteToken } from "@angular/fire/messaging";
+```ts
+import { EnvironmentInjector, Injectable, inject, runInInjectionContext } from "@angular/core";
+import { Messaging, MessagePayload, onMessage, onRegistered, onUnregistered, register, unregister } from "@angular/fire/messaging";
 import { Observable, tap } from "rxjs";
 
-@Injectable({
-  providedIn: "root",
-})
+@Injectable({ providedIn: "root" })
 export class FcmService {
-  message$: Observable<MessagePayload>;
+  private readonly injector = inject(EnvironmentInjector);
+  /* `onMessage` converted to an observable. Returns the unsubscribe function returned by
+   * `onMessage` to stop the listener when the last subscriber unsubscribes. */
+  message$ = new Observable<MessagePayload>(
+    subscriber => onMessage(this.msg, (msg) => subscriber.next(msg))
+  ).pipe(tap((msg) => console.log("My Firebase Cloud Message", msg)));
 
   constructor(private msg: Messaging) {
-    Notification.requestPermission().then(
-      (notificationPermissions: NotificationPermission) => {
-        if (notificationPermissions === "granted") {
-          console.log("Granted");
-        }
-        if (notificationPermissions === "denied") {
-          console.log("Denied");
-        }
-      });
-    navigator.serviceWorker
-      .register("/assets/firebase-messaging-sw.js", {
-        type: "module",
-      })
-      .then((serviceWorkerRegistration) => {
-        getToken(this.msg, {
-          vapidKey: `an optional key generated on Firebase for your fcm tokens`,
-          serviceWorkerRegistration: serviceWorkerRegistration,
-        }).then((token) => {
-          console.log('my fcm token', token);
-          // This is a good place to then store it on your database for each user
-        });
-      });
-    this.message$ = new Observable<MessagePayload>((sub) =>
-      onMessage(this.msg, (msg) => sub.next(msg))).pipe(
-        tap((msg) => {
-          console.log("My Firebase Cloud Message", msg);
-        })
+    // Set listeners before calling `register` to avoid throwing.
+    this.listenForRegistrationChanges();
+    this.registerForMessages();
+  }
+
+  private listenForRegistrationChanges() {
+    onRegistered(this.msg, (installationId) => {
+      /* This is a good place to store it in your database for each user.
+       * This callback fires whenever `installationId` changes. */
+      console.log("my installation id", installationId);
+    });
+
+    onUnregistered(this.msg, (installationId) => {
+      // Drop it from your database. Sending messages to an unregistered ID results in a 404.
+      console.log("no longer registered", installationId);
+    });
+  }
+
+  private async registerForMessages() {
+    /* Request notification permission before calling `register`, otherwise
+     * `register` holds the app unstable until the user answers. */
+    if (
+      Notification.permission === "default" &&
+      await Notification.requestPermission() !== "granted"
+    ) {
+      return;
+    }
+
+    // Register the service worker.
+    const serviceWorkerRegistration = await navigator.serviceWorker
+      .register("/assets/firebase-messaging-sw.js", { type: "module" });
+
+    /* Run `register` inside an injection context. Outside one AngularFire cannot wrap it, and
+     * warns. See `zones.md` for what wrapping adds. */
+    runInInjectionContext(this.injector, () =>
+      register(this.msg, {
+        vapidKey: `an optional public VAPID key you generate for your Firebase project`,
+        serviceWorkerRegistration,
+      }).catch((error) => console.error("could not register for messages", error))
     );
   }
 
-  async deleteToken() {
-    // We can also delete fcm tokens, make sure to also update this on your firestore db if you are storing them as well
-    // This calls the imported deleteToken, not this method. Class methods are not in lexical scope
-    await deleteToken(this.msg);
+  // Called from your app, for example when a user turns notifications off.
+  async unregister() {
+    // This calls the imported unregister, not this method. Class methods are not in lexical scope.
+    await unregister(this.msg);
   }
 }
 ```
@@ -130,9 +157,9 @@ export class FcmService {
 
 Firebase will allow you to send a test notification under Engage > Messaging > New Campaign > Notifications. Here you can click send a test message. Additionally, you can send them programmatically through Firebase cloud functions. 
 
-Here is a barebones Node example:
+Here is a barebones Node example. Its `token` field still accepts a Firebase Installation ID during the migration, so it works whether you registered with `getToken` or with `register`. Firebase's [Admin SDK send guide](https://firebase.google.com/docs/cloud-messaging/send/admin-sdk) documents a dedicated `fid` field to move to.
 
-```
+```ts
 export const sendTestMessage = onRequest(async (_, res) => {
   try {
     const message = {
@@ -153,7 +180,7 @@ export const sendTestMessage = onRequest(async (_, res) => {
 
 Here is a Node example that listens for a new comment on a collection, then sends a notification, and also adds it to a cache on Firebase so users can click through them.
 
-```
+```ts
 exports.onPostReply =
   onDocumentCreated("comments/{commentId}", async (event) => {
     if (!event) throw new Error("No event found for document creation");
@@ -228,4 +255,5 @@ async function createNotificationAndCache(
     firestore.collection("notificationCache").add(notificationCacheValue));
 
   await Promise.all(promises);
-}  ```
+} 
+```

--- a/docs/messaging.md
+++ b/docs/messaging.md
@@ -56,10 +56,11 @@ There are two parts to Firebase Messaging, a Service Worker and the DOM API. Ang
 It may be wise to use file replacements or environments here for different environments
 
 ```
-// This sample application is using 12.4.0, make sure you are importing the same version
+/* Replace <firebase-version> with the firebase version in your package.json. The service
+ * worker and your application have to load the same version. */
 
-import { initializeApp } from "https://www.gstatic.com/firebasejs/12.4.0/firebase-app.js";
-import { getMessaging } from "https://www.gstatic.com/firebasejs/12.4.0/firebase-messaging-sw.js";
+import { initializeApp } from "https://www.gstatic.com/firebasejs/<firebase-version>/firebase-app.js";
+import { getMessaging } from "https://www.gstatic.com/firebasejs/<firebase-version>/firebase-messaging-sw.js";
 
 const firebaseApp = initializeApp({
   apiKey: "",

--- a/docs/version-21-upgrade.md
+++ b/docs/version-21-upgrade.md
@@ -11,7 +11,7 @@ ng update @angular/fire                 # then AngularFire 21
 
 `ng update @angular/fire` runs a migration that:
 
-- **Aligns your `firebase` dependency to `^12.4.0`.** AngularFire 21 requires Firebase JS SDK 12. If your app still requested `firebase` 11, npm would install both 11 and 12 side by side, and the two copies reject each other's objects at runtime. The migration updates the dependency and reinstalls so you end up with a single copy. Verify with `npm ls firebase`.
+- **Aligns your `firebase` dependency to `^12.18.0`.** AngularFire 21 requires Firebase JS SDK 12, at 12.18 or later. If your app requested an older `firebase`, whether that is 11 or an earlier 12, npm would install both that copy and the one AngularFire needs side by side, and the two copies reject each other's objects at runtime. The migration updates the dependency and reinstalls so you end up with a single copy. Verify with `npm ls firebase`.
 - **Rewrites Vertex AI imports to AI Logic** (see below).
 
 ## Vertex AI is now Firebase AI Logic

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@angular/router": "^21.0.0",
         "@schematics/angular": "^21.0.0",
         "esbuild": "^0.24.0",
-        "firebase": "^12.4.0",
+        "firebase": "^12.18.0",
         "firebase-admin": "^13.0.0",
         "firebase-functions": "^6.1.1",
         "fs-extra": "^8.0.1",
@@ -5204,15 +5204,15 @@
       "license": "MIT"
     },
     "node_modules/@firebase/ai": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.4.0.tgz",
-      "integrity": "sha512-YilG6AJ/nYpCKtxZyvEzBRAQv5bU+2tBOKX4Ps0rNNSdxN39aT37kGhjATbk1kq1z5Lq7mkWglw/ajAF3lOWUg==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.15.0.tgz",
+      "integrity": "sha512-Aj7TbFdAIWZdkX8JfdDStERpR35g6WNs+7XhNPtFLFOizUotj6k4N/D8HJkR45165HhnMJBe4hjOeeaxnnn56Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app-check-interop-types": "0.3.3",
-        "@firebase/component": "0.7.0",
-        "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/app-check-interop-types": "0.3.5",
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -5224,15 +5224,15 @@
       }
     },
     "node_modules/@firebase/analytics": {
-      "version": "0.10.19",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.19.tgz",
-      "integrity": "sha512-3wU676fh60gaiVYQEEXsbGS4HbF2XsiBphyvvqDbtC1U4/dO4coshbYktcCHq+HFaGIK07iHOh4pME0hEq1fcg==",
+      "version": "0.10.24",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.24.tgz",
+      "integrity": "sha512-OfIAcIIwoqXjBzS+DnUQpOZ7i3ePaNFg83KPpDWjBZUKJmqMwzzAtLJqmKZOkQnW8im6vFR6f2I3M/9hxVd+QA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/installations": "0.6.19",
-        "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/component": "0.7.5",
+        "@firebase/installations": "0.6.24",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -5240,36 +5240,37 @@
       }
     },
     "node_modules/@firebase/analytics-compat": {
-      "version": "0.2.25",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.25.tgz",
-      "integrity": "sha512-fdzoaG0BEKbqksRDhmf4JoyZf16Wosrl0Y7tbZtJyVDOOwziE0vrFjmZuTdviL0yhak+Nco6rMsUUbkbD+qb6Q==",
+      "version": "0.2.30",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.30.tgz",
+      "integrity": "sha512-uVZEKlLaW4AHAhv8zoN9cTmveX6v86AVqcJ4LCaRCMTChTH8/NsjbisTq1lpBfWCLWS1spqwSHB4vol/YSCdMA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/analytics": "0.10.19",
-        "@firebase/analytics-types": "0.8.3",
-        "@firebase/component": "0.7.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/analytics": "0.10.24",
+        "@firebase/analytics-types": "0.8.5",
+        "@firebase/component": "0.7.5",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
+        "@firebase/app": "0.x",
         "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/analytics-types": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.3.tgz",
-      "integrity": "sha512-VrIp/d8iq2g501qO46uGz3hjbDb8xzYMrbu8Tp0ovzIzrvJZ2fvmj649gTjge/b7cCCcjT0H37g1gVtlNhnkbg==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.5.tgz",
+      "integrity": "sha512-kdnooE7Bis2jEnsqcerRwn/UQpH5D3uvHpku7OdUM9TJN3omlu6iYtbyAQ6XkAJRgJtO0aNf9OOkW8J6D59oCA==",
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/app": {
-      "version": "0.14.4",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.4.tgz",
-      "integrity": "sha512-pUxEGmR+uu21OG/icAovjlu1fcYJzyVhhT0rsCrn+zi+nHtrS43Bp9KPn9KGa4NMspCUE++nkyiqziuIvJdwzw==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.16.1.tgz",
+      "integrity": "sha512-tjUEorFyKrurH7PbLWv9zDHRuU4mLefgD/yY38D584ziorIRlQz/PVjx4c/SCGyCuUlmyzt72mK+Lh+COAywNQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
         "idb": "7.1.1",
         "tslib": "^2.1.0"
       },
@@ -5278,14 +5279,14 @@
       }
     },
     "node_modules/@firebase/app-check": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.11.0.tgz",
-      "integrity": "sha512-XAvALQayUMBJo58U/rxW02IhsesaxxfWVmVkauZvGEz3vOAjMEQnzFlyblqkc2iAaO82uJ2ZVyZv9XzPfxjJ6w==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.13.1.tgz",
+      "integrity": "sha512-l8y3dmnhodXks/APAwx4tWqRl3tk8b9874KF1FJyKg1DIU+kMD0l52iz7S9/MW+eK8k6cjJg0G0iJ5KQAsQpow==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -5296,68 +5297,16 @@
       }
     },
     "node_modules/@firebase/app-check-compat": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.4.0.tgz",
-      "integrity": "sha512-UfK2Q8RJNjYM/8MFORltZRG9lJj11k0nW84rrffiKvcJxLf1jf6IEjCIkCamykHE73C6BwqhVfhIBs69GXQV0g==",
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.4.7.tgz",
+      "integrity": "sha512-fBb/xSMyIKv1nDmccfzz3IAGBzx/cQOxmZai66rJzifb1hMMkztf824Xx7LhpTUe7HNUbXwY90IvJ66fi8q6yg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app-check": "0.11.0",
-        "@firebase/app-check-types": "0.5.3",
-        "@firebase/component": "0.7.0",
-        "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "@firebase/app-compat": "0.x"
-      }
-    },
-    "node_modules/@firebase/app-check-interop-types": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.3.tgz",
-      "integrity": "sha512-gAlxfPLT2j8bTI/qfe3ahl2I2YcBQ8cFIBdhAQA4I2f3TndcO+22YizyGYuttLHPQEpWkhmpFW60VCFEPg4g5A==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@firebase/app-check-types": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.3.tgz",
-      "integrity": "sha512-hyl5rKSj0QmwPdsAxrI5x1otDlByQ7bvNvVt8G/XPO2CSwE++rmSVf3VEhaeOR4J8ZFaF0Z0NDSmLejPweZ3ng==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@firebase/app-compat": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.4.tgz",
-      "integrity": "sha512-T7ifGmb+awJEcp542Ek4HtNfBxcBrnuk1ggUdqyFEdsXHdq7+wVlhvE6YukTL7NS8hIkEfL7TMAPx/uCNqt30g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/app": "0.14.4",
-        "@firebase/component": "0.7.0",
-        "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@firebase/app-types": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
-      "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@firebase/auth": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.11.0.tgz",
-      "integrity": "sha512-5j7+ua93X+IRcJ1oMDTClTo85l7Xe40WSkoJ+shzPrX7OISlVWLdE1mKC57PSD+/LfAbdhJmvKixINBw2ESK6w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/app-check": "0.13.1",
+        "@firebase/app-check-types": "0.5.5",
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -5365,7 +5314,63 @@
       },
       "peerDependencies": {
         "@firebase/app": "0.x",
-        "@react-native-async-storage/async-storage": "^1.18.1"
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-interop-types": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.5.tgz",
+      "integrity": "sha512-qId34pVZ2CXTmtu4ofW5leiI93DvnOvIcr/5GT7MZPw5WXAi6nZoU+g9cNRgl7K90UJSbK0cXxten4meYMPyZg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-check-types": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.5.tgz",
+      "integrity": "sha512-+DF4gzFrlwGFyky38o4T/YN/r51l70yCtJ2HTkwmRj8FCMwPjm4hLH4fQbj6BUvzkiFqliBkitFsRpf1/YZkWA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-compat": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.17.tgz",
+      "integrity": "sha512-5GdJWobqs6jbNYOnaQiSa4Ng8gnFerhqr7nY+v5jlnT7o9QbEeIZRLPQpnLe0TxYSWfRV2lAMbyR0kbXeIos9Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app": "0.16.1",
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-types": {
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.6.tgz",
+      "integrity": "sha512-yPLahy7Esfu2w/yme3msVK4xTkDXQqq6szfQn8yVOQpCKiT5GVFjqNpLbuz6NkX0WuTwUidkmPewW3r4xkvpeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/logger": "0.5.2"
+      }
+    },
+    "node_modules/@firebase/auth": {
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.13.5.tgz",
+      "integrity": "sha512-1AXoBJqBVD8WL8FZYo3S2GmJF9YUoom6Y6ngMxOSkzzhW5sT83pLchb6TGFgxes91dfXx8s/VYc5VrLDNqpLog==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@react-native-async-storage/async-storage": "^2.2.0 || ^3.0.0"
       },
       "peerDependenciesMeta": {
         "@react-native-async-storage/async-storage": {
@@ -5374,34 +5379,35 @@
       }
     },
     "node_modules/@firebase/auth-compat": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.0.tgz",
-      "integrity": "sha512-J0lGSxXlG/lYVi45wbpPhcWiWUMXevY4fvLZsN1GHh+po7TZVng+figdHBVhFheaiipU8HZyc7ljw1jNojM2nw==",
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.10.tgz",
+      "integrity": "sha512-Bvklg2nL7BrBFCAqdsleW8fse9Jh0fARqJPlJmA40uermfWx1bJiO7dnKyZN3J39d2TFVd4VJXtg3i6Wg92/YQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/auth": "1.11.0",
-        "@firebase/auth-types": "0.13.0",
-        "@firebase/component": "0.7.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/auth": "1.13.5",
+        "@firebase/auth-types": "0.13.2",
+        "@firebase/component": "0.7.5",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
+        "@firebase/app": "0.x",
         "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/auth-interop-types": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.4.tgz",
-      "integrity": "sha512-JPgcXKCuO+CWqGDnigBtvo09HeBs5u/Ktc2GaFj2m01hLarbxthLNm7Fk8iOP1aqAtXV+fnnGj7U28xmk7IwVA==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.6.tgz",
+      "integrity": "sha512-FgwZqDrBqgK0BHI70QTv1v/5wmuDF9f8fsJFvKSxoRlK2PPfSQtZAk2jhXu4pe9BZzFi/e4UYusU/bEQHdf6Qg==",
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/auth-types": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.13.0.tgz",
-      "integrity": "sha512-S/PuIjni0AQRLF+l9ck0YpsMOdE8GO2KU6ubmBB7P+7TJUCQDa3R1dlgYm9UzGbbePMZsp0xzB93f2b/CgxMOg==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.13.2.tgz",
+      "integrity": "sha512-OU+miuoSxIWYN7GT291d2ylVJBL3k/OePo7/JDSoQtkFQoEiGBc4AHuMjj/seqFIsHrqnjrAfRCk4pfufoJolQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@firebase/app-types": "0.x",
@@ -5409,12 +5415,12 @@
       }
     },
     "node_modules/@firebase/component": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.0.tgz",
-      "integrity": "sha512-wR9En2A+WESUHexjmRHkqtaVH94WLNKt6rmeqZhSLBybg4Wyf0Umk04SZsS6sBq4102ZsDBFwoqMqJYj2IoDSg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.5.tgz",
+      "integrity": "sha512-vuFDcL91Q+2ZuBJkyOh86T4q0B4ffNTDjc/A38tybO56odQABxRTFLTIowCWqAKeIcgo37GowWMVgFF73gD8Qw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/util": "1.13.0",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -5422,15 +5428,15 @@
       }
     },
     "node_modules/@firebase/data-connect": {
-      "version": "0.3.11",
-      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.3.11.tgz",
-      "integrity": "sha512-G258eLzAD6im9Bsw+Qm1Z+P4x0PGNQ45yeUuuqe5M9B1rn0RJvvsQCRHXgE52Z+n9+WX1OJd/crcuunvOGc7Vw==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.7.4.tgz",
+      "integrity": "sha512-su1aGWlzhxb+xtggCUSsufJn1FDa06SBDK71y+fpQ+g2zMhMExik6FUv/odkKzOF/xfWVjabCbWBcjJY3MceDA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/auth-interop-types": "0.2.4",
-        "@firebase/component": "0.7.0",
-        "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/auth-interop-types": "0.2.6",
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -5438,16 +5444,16 @@
       }
     },
     "node_modules/@firebase/database": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.0.tgz",
-      "integrity": "sha512-gM6MJFae3pTyNLoc9VcJNuaUDej0ctdjn3cVtILo3D5lpp0dmUHHLFN/pUKe7ImyeB1KAvRlEYxvIHNF04Filg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.5.tgz",
+      "integrity": "sha512-/JGpvszLoNXNgzilRXocigGfFF4hbcPA9wN1i1kjJx6oKkXgkHteZYl3lQs1lJX3ETDf6bv7zI15lPMVUp4sAQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app-check-interop-types": "0.3.3",
-        "@firebase/auth-interop-types": "0.2.4",
-        "@firebase/component": "0.7.0",
-        "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/app-check-interop-types": "0.3.5",
+        "@firebase/auth-interop-types": "0.2.6",
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
         "faye-websocket": "0.11.4",
         "tslib": "^2.1.0"
       },
@@ -5456,44 +5462,57 @@
       }
     },
     "node_modules/@firebase/database-compat": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.0.tgz",
-      "integrity": "sha512-8nYc43RqxScsePVd1qe1xxvWNf0OBnbwHxmXJ7MHSuuTVYFO3eLyLW3PiCKJ9fHnmIz4p4LbieXwz+qtr9PZDg==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.7.tgz",
+      "integrity": "sha512-lBq9sJm8MnJINKJnkAKSOj2MbC66xGoSVCcGkPtstl+lkoKEBtD46qHLbuDgW/WbLPoKVm17RIN8BxHj+Z2F2w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/database": "1.1.0",
-        "@firebase/database-types": "1.0.16",
-        "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/component": "0.7.5",
+        "@firebase/database": "1.1.5",
+        "@firebase/database-types": "1.0.22",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "engines": {
         "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-compat": "0.x"
+      },
+      "peerDependenciesMeta": {
+        "@firebase/app": {
+          "optional": true
+        },
+        "@firebase/app-compat": {
+          "optional": true
+        }
       }
     },
     "node_modules/@firebase/database-types": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.16.tgz",
-      "integrity": "sha512-xkQLQfU5De7+SPhEGAXFBnDryUWhhlFXelEg2YeZOQMCdoe7dL64DDAd77SQsR+6uoXIZY5MB4y/inCs4GTfcw==",
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.22.tgz",
+      "integrity": "sha512-YAZNXsjY9EQQ+pKw/3ax8n5FgolHC7Qew7EY5RceYdl0R2ZP+kCv1O0DkKlcceue8uQCOreHCNN7PWVFpY1Nug==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app-types": "0.9.3",
-        "@firebase/util": "1.13.0"
+        "@firebase/app-types": "0.9.6",
+        "@firebase/util": "1.15.3"
       }
     },
     "node_modules/@firebase/firestore": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.9.2.tgz",
-      "integrity": "sha512-iuA5+nVr/IV/Thm0Luoqf2mERUvK9g791FZpUJV1ZGXO6RL2/i/WFJUj5ZTVXy5pRjpWYO+ZzPcReNrlilmztA==",
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.17.1.tgz",
+      "integrity": "sha512-8lqPNf2w10CtYG+tayVjZO1pSyQpnhztQRudeD109VtXDzNbASTaYdO43sj5PMsDcWq0aOYY3RmJOUlXu9++jw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
-        "@firebase/webchannel-wrapper": "1.0.5",
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
+        "@firebase/webchannel-wrapper": "1.0.7",
         "@grpc/grpc-js": "~1.9.0",
         "@grpc/proto-loader": "^0.7.8",
+        "re2js": "^2.8.3",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -5504,28 +5523,29 @@
       }
     },
     "node_modules/@firebase/firestore-compat": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.2.tgz",
-      "integrity": "sha512-cy7ov6SpFBx+PHwFdOOjbI7kH00uNKmIFurAn560WiPCZXy9EMnil1SOG7VF4hHZKdenC+AHtL4r3fNpirpm0w==",
+      "version": "0.4.13",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.13.tgz",
+      "integrity": "sha512-l9dCewxMzzLOIhcwTjERCKxrWOn1kZ9JvwOQq9zZNq4I/Nbvb/B9njT230V61uvQ9qZ3/qpUG758D8DDTEFXnw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/firestore": "4.9.2",
-        "@firebase/firestore-types": "3.0.3",
-        "@firebase/util": "1.13.0",
+        "@firebase/component": "0.7.5",
+        "@firebase/firestore": "4.17.1",
+        "@firebase/firestore-types": "3.0.5",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
+        "@firebase/app": "0.x",
         "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/firestore-types": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.3.tgz",
-      "integrity": "sha512-hD2jGdiWRxB/eZWF89xcK9gF8wvENDJkzpVFb4aGkzfEaKxVRD1kjz1t1Wj8VZEp2LCB53Yx1zD8mrhQu87R6Q==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.5.tgz",
+      "integrity": "sha512-dbdMAQkMd5dwWc48eupz/Y6/E9ruat3+gY5lhVKscvvT/HnDBEEMzJW38zdKhgdnglZHGk2vUsJMOHAphMHGMA==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@firebase/app-types": "0.x",
@@ -5533,16 +5553,16 @@
       }
     },
     "node_modules/@firebase/functions": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.13.1.tgz",
-      "integrity": "sha512-sUeWSb0rw5T+6wuV2o9XNmh9yHxjFI9zVGFnjFi+n7drTEWpl7ZTz1nROgGrSu472r+LAaj+2YaSicD4R8wfbw==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.14.0.tgz",
+      "integrity": "sha512-DhuYFr0eMhp+s/PNEk6SiMsYkc00+XVOUeKbrl8MOzQNZI3SKQpqoDR1d+keNDAutwmHRWTUAdXBoVPD+xxVUw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app-check-interop-types": "0.3.3",
-        "@firebase/auth-interop-types": "0.2.4",
-        "@firebase/component": "0.7.0",
-        "@firebase/messaging-interop-types": "0.2.3",
-        "@firebase/util": "1.13.0",
+        "@firebase/app-check-interop-types": "0.3.5",
+        "@firebase/auth-interop-types": "0.2.6",
+        "@firebase/component": "0.7.5",
+        "@firebase/messaging-interop-types": "0.2.6",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -5553,38 +5573,39 @@
       }
     },
     "node_modules/@firebase/functions-compat": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.4.1.tgz",
-      "integrity": "sha512-AxxUBXKuPrWaVNQ8o1cG1GaCAtXT8a0eaTDfqgS5VsRYLAR0ALcfqDLwo/QyijZj1w8Qf8n3Qrfy/+Im245hOQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.5.0.tgz",
+      "integrity": "sha512-T3BDIToESZUHt7438wyKYMkRjKg3m1xAIux5fVpNvTRQlDOFLukWniQWBDhJ2znpU9kxMTR6+e31TVo8P15PZw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/functions": "0.13.1",
-        "@firebase/functions-types": "0.6.3",
-        "@firebase/util": "1.13.0",
+        "@firebase/component": "0.7.5",
+        "@firebase/functions": "0.14.0",
+        "@firebase/functions-types": "0.6.5",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
+        "@firebase/app": "0.x",
         "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/functions-types": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.3.tgz",
-      "integrity": "sha512-EZoDKQLUHFKNx6VLipQwrSMh01A1SaL3Wg6Hpi//x6/fJ6Ee4hrAeswK99I5Ht8roiniKHw4iO0B1Oxj5I4plg==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.5.tgz",
+      "integrity": "sha512-Zc0pURjthHXzSj54ZivCkzKDSV1r/wIpnmHdhq82q2yFFPVoncG/ZJjnVMiANvQfeww/QnElhzODpfwUucVwdA==",
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/installations": {
-      "version": "0.6.19",
-      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.19.tgz",
-      "integrity": "sha512-nGDmiwKLI1lerhwfwSHvMR9RZuIH5/8E3kgUWnVRqqL7kGVSktjLTWEMva7oh5yxQ3zXfIlIwJwMcaM5bK5j8Q==",
+      "version": "0.6.24",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.24.tgz",
+      "integrity": "sha512-Ui52ey8wHoWqkBbXRKJEKYWylI0JZogZmoLS+o8Anh1bxWtK27ZYjLla1UJAAdC5DCKLJ2qAp0VpJOjg8VOX1g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/component": "0.7.5",
+        "@firebase/util": "1.15.3",
         "idb": "7.1.1",
         "tslib": "^2.1.0"
       },
@@ -5593,34 +5614,35 @@
       }
     },
     "node_modules/@firebase/installations-compat": {
-      "version": "0.2.19",
-      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.19.tgz",
-      "integrity": "sha512-khfzIY3EI5LePePo7vT19/VEIH1E3iYsHknI/6ek9T8QCozAZshWT9CjlwOzZrKvTHMeNcbpo/VSOSIWDSjWdQ==",
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.24.tgz",
+      "integrity": "sha512-8M5nlcWwYt881x83COP2odq5vgf+NgwJh+RMd4LRSv8JI1pxwDfgrDJOERrjTgfC9J5Z0vnQX4b1pdN914e0Zw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/installations": "0.6.19",
-        "@firebase/installations-types": "0.5.3",
-        "@firebase/util": "1.13.0",
+        "@firebase/component": "0.7.5",
+        "@firebase/installations": "0.6.24",
+        "@firebase/installations-types": "0.5.5",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
+        "@firebase/app": "0.x",
         "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/installations-types": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.3.tgz",
-      "integrity": "sha512-2FJI7gkLqIE0iYsNQ1P751lO3hER+Umykel+TkLwHj6plzWVxqvfclPUZhcKFVQObqloEBTmpi2Ozn7EkCABAA==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.5.tgz",
+      "integrity": "sha512-e9UYcju3puDl1vdrcKIi5dExzHLameOT/Tc61Q48PYwxtsM1NzZh/ikGbdBQTsbRgg0EMZqdPr0/m5ODUBobrg==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@firebase/app-types": "0.x"
       }
     },
     "node_modules/@firebase/logger": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.0.tgz",
-      "integrity": "sha512-cGskaAvkrnh42b3BA3doDWeBmuHFO/Mx5A83rbRDYakPjO9bJtRL3dX7javzc2Rr/JHZf4HlterTW2lUkfeN4g==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.2.tgz",
+      "integrity": "sha512-J2VO4NFTc0xQFrxV1B/lm5balicm9cwuX2acR9Yn41fN8KgUeQFo+VJV222IqW2FPSXKDu9uo5WdQFWf9TPbYg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -5630,15 +5652,15 @@
       }
     },
     "node_modules/@firebase/messaging": {
-      "version": "0.12.23",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.23.tgz",
-      "integrity": "sha512-cfuzv47XxqW4HH/OcR5rM+AlQd1xL/VhuaeW/wzMW1LFrsFcTn0GND/hak1vkQc2th8UisBcrkVcQAnOnKwYxg==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.13.2.tgz",
+      "integrity": "sha512-KcZoqUu2ih4sLH91dW9tmyHjCR0IQyNzSLZunX5uq7cLeImXb4uO2I0wq5FACduO2I+FoTeWa2BtUv7Jpowqdw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/installations": "0.6.19",
-        "@firebase/messaging-interop-types": "0.2.3",
-        "@firebase/util": "1.13.0",
+        "@firebase/component": "0.7.5",
+        "@firebase/installations": "0.6.24",
+        "@firebase/messaging-interop-types": "0.2.6",
+        "@firebase/util": "1.15.3",
         "idb": "7.1.1",
         "tslib": "^2.1.0"
       },
@@ -5647,36 +5669,37 @@
       }
     },
     "node_modules/@firebase/messaging-compat": {
-      "version": "0.2.23",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.23.tgz",
-      "integrity": "sha512-SN857v/kBUvlQ9X/UjAqBoQ2FEaL1ZozpnmL1ByTe57iXkmnVVFm9KqAsTfmf+OEwWI4kJJe9NObtN/w22lUgg==",
+      "version": "0.2.29",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.29.tgz",
+      "integrity": "sha512-8Twe4CeYvAx8AzjBxyyQFKzinaMGGt13hPQBqaARQ2QZjagrEaqSVBe+Zy6F4L/vT8DV168yRgRu7W/RK7p+4w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/messaging": "0.12.23",
-        "@firebase/util": "1.13.0",
+        "@firebase/component": "0.7.5",
+        "@firebase/messaging": "0.13.2",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
+        "@firebase/app": "0.x",
         "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/messaging-interop-types": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.3.tgz",
-      "integrity": "sha512-xfzFaJpzcmtDjycpDeCUj0Ge10ATFi/VHVIvEEjDNc3hodVBQADZ7BWQU7CuFpjSHE+eLuBI13z5F/9xOoGX8Q==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.6.tgz",
+      "integrity": "sha512-MVzvkKe2V4H2dHu5oOxRfeKQcfTwWmCgnzsC4V1q3ixun5iiL8riCZ2qI35rDhCL4glPGiu0jHxDbpVNuTKfow==",
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/performance": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.9.tgz",
-      "integrity": "sha512-UzybENl1EdM2I1sjYm74xGt/0JzRnU/0VmfMAKo2LSpHJzaj77FCLZXmYQ4oOuE+Pxtt8Wy2BVJEENiZkaZAzQ==",
+      "version": "0.7.14",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.14.tgz",
+      "integrity": "sha512-9PH1XEZVHErxGdbXluvGz4Uyjw4W955H8v7Mv9rHIybRrg5F2Ac2tvf5+mSf5EtnxWNmxrD2WLnvMFaZP4sMrQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/installations": "0.6.19",
-        "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/component": "0.7.5",
+        "@firebase/installations": "0.6.24",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0",
         "web-vitals": "^4.2.4"
       },
@@ -5685,38 +5708,39 @@
       }
     },
     "node_modules/@firebase/performance-compat": {
-      "version": "0.2.22",
-      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.22.tgz",
-      "integrity": "sha512-xLKxaSAl/FVi10wDX/CHIYEUP13jXUjinL+UaNXT9ByIvxII5Ne5150mx6IgM8G6Q3V+sPiw9C8/kygkyHUVxg==",
+      "version": "0.2.27",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.27.tgz",
+      "integrity": "sha512-O/ozTf/EbChN94Pk7bd1eUC0PAC36726AwsaiJyC0bZzSBWfLGSWASGPH5pebUWXQPJtGxIJYRkkbX5l0Qa+Hw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/logger": "0.5.0",
-        "@firebase/performance": "0.7.9",
-        "@firebase/performance-types": "0.2.3",
-        "@firebase/util": "1.13.0",
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/performance": "0.7.14",
+        "@firebase/performance-types": "0.2.5",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
+        "@firebase/app": "0.x",
         "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/performance-types": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.3.tgz",
-      "integrity": "sha512-IgkyTz6QZVPAq8GSkLYJvwSLr3LS9+V6vNPQr0x4YozZJiLF5jYixj0amDtATf1X0EtYHqoPO48a9ija8GocxQ==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.5.tgz",
+      "integrity": "sha512-PRzOgB+/M+6AKlEkY8a9xy5Ff5SfZPIh4iShXhn2WAcL/euSbK7bdLqWysHduunNJhGFsXa22Ag3ixqL6rQtYg==",
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/remote-config": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.7.0.tgz",
-      "integrity": "sha512-dX95X6WlW7QlgNd7aaGdjAIZUiQkgWgNS+aKNu4Wv92H1T8Ue/NDUjZHd9xb8fHxLXIHNZeco9/qbZzr500MjQ==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.9.2.tgz",
+      "integrity": "sha512-Rii93DkXjM+RE/ytHdYa7EIiQLJbdBr+W8EEiqd/vbLCOC+1FdkDuRiumJBp6t3yewHGbdqbpjB3fk3z0cZ+8g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/installations": "0.6.19",
-        "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/component": "0.7.5",
+        "@firebase/installations": "0.6.24",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -5724,36 +5748,37 @@
       }
     },
     "node_modules/@firebase/remote-config-compat": {
-      "version": "0.2.20",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.20.tgz",
-      "integrity": "sha512-P/ULS9vU35EL9maG7xp66uljkZgcPMQOxLj3Zx2F289baTKSInE6+YIkgHEi1TwHoddC/AFePXPpshPlEFkbgg==",
+      "version": "0.2.29",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.29.tgz",
+      "integrity": "sha512-mY7JtTISK6F4g4T0x3kVepr5cp0NXL7f5yjIUXXGaTrg4qUlFBWRbENaHaqZ78dwmNcLm24h/yPsOVRlDXEXhA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/logger": "0.5.0",
-        "@firebase/remote-config": "0.7.0",
-        "@firebase/remote-config-types": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/remote-config": "0.9.2",
+        "@firebase/remote-config-types": "0.5.2",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
+        "@firebase/app": "0.x",
         "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/remote-config-types": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.5.0.tgz",
-      "integrity": "sha512-vI3bqLoF14L/GchtgayMiFpZJF+Ao3uR8WCde0XpYNkSokDpAKca2DxvcfeZv7lZUqkUwQPL2wD83d3vQ4vvrg==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.5.2.tgz",
+      "integrity": "sha512-i8k1omVfoAnaT1ZPv2FFjxMZrATYsO/GnFgHEj5+7fAJLzi8wLnGGv1WK06oEAD6ltrWXSO1HzeNyajn/NjMWw==",
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/storage": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.14.0.tgz",
-      "integrity": "sha512-xWWbb15o6/pWEw8H01UQ1dC5U3rf8QTAzOChYyCpafV6Xki7KVp3Yaw2nSklUwHEziSWE9KoZJS7iYeyqWnYFA==",
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.14.5.tgz",
+      "integrity": "sha512-r2tozN/BlEewLi70tJNUQPzWwbex9GM7NgXZsamHKQrjKEfcR0i4jGgHBKAKA4hbwiPE9eNMb3hcxWnDpeJZwg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/component": "0.7.5",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -5764,28 +5789,29 @@
       }
     },
     "node_modules/@firebase/storage-compat": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.4.0.tgz",
-      "integrity": "sha512-vDzhgGczr1OfcOy285YAPur5pWDEvD67w4thyeCUh6Ys0izN9fNYtA1MJERmNBfqjqu0lg0FM5GLbw0Il21M+g==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.4.5.tgz",
+      "integrity": "sha512-vO0tFPxXbKDKdlTu8tYT08S9t9ezUTJYEdLCULpWxWq2aq6zojwN1QmAB+1a50AI/g47GlWUJn1XPncm/PDZsw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/storage": "0.14.0",
-        "@firebase/storage-types": "0.8.3",
-        "@firebase/util": "1.13.0",
+        "@firebase/component": "0.7.5",
+        "@firebase/storage": "0.14.5",
+        "@firebase/storage-types": "0.8.5",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
+        "@firebase/app": "0.x",
         "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/storage-types": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.3.tgz",
-      "integrity": "sha512-+Muk7g9uwngTpd8xn9OdF/D48uiQ7I1Fae7ULsWPuKoCH3HU7bfFPhxtJYzyhjdniowhuDpQcfPmuNRAqZEfvg==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.5.tgz",
+      "integrity": "sha512-GEDs5P+rNUfNcS+wxIdOLAHficife2YXtvTJnyi3ssrX11AAtBg+nDUdbYh8vuBzWehVQZPmztGUUnud4L+4yg==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@firebase/app-types": "0.x",
@@ -5793,9 +5819,9 @@
       }
     },
     "node_modules/@firebase/util": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.13.0.tgz",
-      "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.15.3.tgz",
+      "integrity": "sha512-c/z/gaIlaaLZEuGbE6sLUuJ61tskg1JghvhcNQzW948ASBinbVBBRnZTC4b4yt4LaEtJQkYlyzqLHcutFwEIvA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5806,9 +5832,9 @@
       }
     },
     "node_modules/@firebase/webchannel-wrapper": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.5.tgz",
-      "integrity": "sha512-+uGNN7rkfn41HLO0vekTFhTxk61eKa8mTpRGLO0QSqlQdKvIoGAvLp3ppdVIWbTGYJWM6Kp0iN+PjMIOcnVqTw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.7.tgz",
+      "integrity": "sha512-phBFwieDLvkZGYN9CE9ZFNEIoBVksprzsnCzQejCmCHtgwCXReeuRpoEGN9C4EbhONztv8NRV1tau6Rb9pONwQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@google-cloud/firestore": {
@@ -5900,9 +5926,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.9.15",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.15.tgz",
-      "integrity": "sha512-nqE7Hc0AzI+euzUwDAy0aY5hCp10r734gMGRdU+qOPX0XSceI2ULrcXB5U2xSc5VkWwalCj4M7GzCAygZl2KoQ==",
+      "version": "1.9.16",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.16.tgz",
+      "integrity": "sha512-wE4Ut/olIzfKqp631XrG+wbF0v1vWFN4YL9FyXC2LJiG33DsV7PLzURjrCvY/6je2ntdRkeLpPDluzSRGaVltQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.8",
@@ -5913,13 +5939,19 @@
       }
     },
     "node_modules/@grpc/grpc-js/node_modules/@types/node": {
-      "version": "24.7.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.7.1.tgz",
-      "integrity": "sha512-CmyhGZanP88uuC5GpWU9q+fI61j2SkhO3UGMUdfYRE6Bcy0ccyzn1Rqj9YAB/ZY4kOXmNf0ocah5GtphmLMP6Q==",
+      "version": "26.4.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
+      "integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.14.0"
+        "undici-types": "~8.3.0"
       }
+    },
+    "node_modules/@grpc/grpc-js/node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT"
     },
     "node_modules/@grpc/proto-loader": {
       "version": "0.7.15",
@@ -13533,39 +13565,39 @@
       }
     },
     "node_modules/firebase": {
-      "version": "12.4.0",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.4.0.tgz",
-      "integrity": "sha512-/chNgDQ6ppPPGOQO4jctxOa/5JeQxuhaxA7Y90K0I+n/wPfoO8mRveedhVUdo7ExLcWUivnnow/ouSLYSI5Icw==",
+      "version": "12.18.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.18.0.tgz",
+      "integrity": "sha512-XaL6tlE5Xd20ZDhckqOMIw+JJTET+wTdeZPxQ7ihc42oxRb7kWUyn/j1LO5V9dH1xq8Rv5R71Pv1fBCdIkt9Rw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/ai": "2.4.0",
-        "@firebase/analytics": "0.10.19",
-        "@firebase/analytics-compat": "0.2.25",
-        "@firebase/app": "0.14.4",
-        "@firebase/app-check": "0.11.0",
-        "@firebase/app-check-compat": "0.4.0",
-        "@firebase/app-compat": "0.5.4",
-        "@firebase/app-types": "0.9.3",
-        "@firebase/auth": "1.11.0",
-        "@firebase/auth-compat": "0.6.0",
-        "@firebase/data-connect": "0.3.11",
-        "@firebase/database": "1.1.0",
-        "@firebase/database-compat": "2.1.0",
-        "@firebase/firestore": "4.9.2",
-        "@firebase/firestore-compat": "0.4.2",
-        "@firebase/functions": "0.13.1",
-        "@firebase/functions-compat": "0.4.1",
-        "@firebase/installations": "0.6.19",
-        "@firebase/installations-compat": "0.2.19",
-        "@firebase/messaging": "0.12.23",
-        "@firebase/messaging-compat": "0.2.23",
-        "@firebase/performance": "0.7.9",
-        "@firebase/performance-compat": "0.2.22",
-        "@firebase/remote-config": "0.7.0",
-        "@firebase/remote-config-compat": "0.2.20",
-        "@firebase/storage": "0.14.0",
-        "@firebase/storage-compat": "0.4.0",
-        "@firebase/util": "1.13.0"
+        "@firebase/ai": "2.15.0",
+        "@firebase/analytics": "0.10.24",
+        "@firebase/analytics-compat": "0.2.30",
+        "@firebase/app": "0.16.1",
+        "@firebase/app-check": "0.13.1",
+        "@firebase/app-check-compat": "0.4.7",
+        "@firebase/app-compat": "0.5.17",
+        "@firebase/app-types": "0.9.6",
+        "@firebase/auth": "1.13.5",
+        "@firebase/auth-compat": "0.6.10",
+        "@firebase/data-connect": "0.7.4",
+        "@firebase/database": "1.1.5",
+        "@firebase/database-compat": "2.1.7",
+        "@firebase/firestore": "4.17.1",
+        "@firebase/firestore-compat": "0.4.13",
+        "@firebase/functions": "0.14.0",
+        "@firebase/functions-compat": "0.5.0",
+        "@firebase/installations": "0.6.24",
+        "@firebase/installations-compat": "0.2.24",
+        "@firebase/messaging": "0.13.2",
+        "@firebase/messaging-compat": "0.2.29",
+        "@firebase/performance": "0.7.14",
+        "@firebase/performance-compat": "0.2.27",
+        "@firebase/remote-config": "0.9.2",
+        "@firebase/remote-config-compat": "0.2.29",
+        "@firebase/storage": "0.14.5",
+        "@firebase/storage-compat": "0.4.5",
+        "@firebase/util": "1.15.3"
       }
     },
     "node_modules/firebase-admin": {
@@ -21122,6 +21154,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/re2js": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/re2js/-/re2js-2.8.6.tgz",
+      "integrity": "sha512-xLgQil4kIUCrAzVk9fRSkxkFNwmygLFjVxXrLc65aE1F0+Zsb8rxumFBy4XKyvgMCTL6kilDq3EZ0piE2dP/Dg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/read-pkg": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@angular/router": "^21.0.0",
     "@schematics/angular": "^21.0.0",
     "esbuild": "^0.24.0",
-    "firebase": "^12.4.0",
+    "firebase": "^12.18.0",
     "firebase-admin": "^13.0.0",
     "firebase-functions": "^6.1.1",
     "fs-extra": "^8.0.1",

--- a/sample/package-lock.json
+++ b/sample/package-lock.json
@@ -19,7 +19,7 @@
         "@angular/ssr": "^21.0.0",
         "cookie-parser": "^1.4.7",
         "express": "^5.1.0",
-        "firebase": "^12.4.0",
+        "firebase": "^12.18.0",
         "firebase-admin": "^13.0.1",
         "js-cookie": "^3.0.5",
         "rxjs": "~7.8.0",
@@ -274,7 +274,6 @@
       "version": "0.2102.19",
       "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2102.19.tgz",
       "integrity": "sha512-cj4tzUMiloLTg5rNf17E8MsvIxCWYoBiBsaj7ns6dgXqT9XCeG+J0TA2t1M+N9uuqfeLd22U/rYoCkADmcircQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@angular-devkit/core": "21.2.19",
@@ -685,12 +684,15 @@
     "node_modules/@angular/fire": {
       "version": "21.0.0-rc.0",
       "resolved": "file:../angular-fire-21.0.0-rc.0.tgz",
-      "integrity": "sha512-obIjLH/mX7lrkHQh1frbaKB06Bv4aVuKgwtAUP5k8m0XLnPVKiewqdZulllg5SnjobIa8GimZU0/k/M/O92fCw==",
+      "integrity": "sha512-jayr/zD9AM4HbD7z55lXUYByha1UST9PqX6yeNyc7a8GTfrTGofThhjorJylRBh+rIVt07VOepkXZaFkR7MKJA==",
       "license": "MIT",
       "dependencies": {
+        "@angular-devkit/architect": ">= 0.2100.0 < 0.2200.0",
+        "@angular-devkit/core": "^21.0.0",
         "@angular-devkit/schematics": "^21.0.0",
         "@schematics/angular": "^21.0.0",
-        "firebase": "^12.4.0",
+        "firebase": "^12.18.0",
+        "jsonc-parser": "^3.0.0",
         "rxfire": "^6.2.0",
         "tslib": "^2.3.0"
       },
@@ -700,13 +702,17 @@
         "@angular/platform-browser": "^21.0.0",
         "@angular/platform-server": "^21.0.0",
         "firebase-tools": "^14.0.0 || ^15.0.0",
-        "rxjs": "~7.8.0"
+        "rxjs": "~7.8.0",
+        "typescript": ">=5.8 <6.0"
       },
       "peerDependenciesMeta": {
         "@angular/platform-server": {
           "optional": true
         },
         "firebase-tools": {
+          "optional": true
+        },
+        "typescript": {
           "optional": true
         }
       }
@@ -1888,15 +1894,15 @@
       "license": "MIT"
     },
     "node_modules/@firebase/ai": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.13.1.tgz",
-      "integrity": "sha512-RhT/VViTPBSplhQSuEp62HhLvfsV+LowMh8ZUo5MMRDzG7oFtSget4Kmg5oHP50hDVyWQuQj6to9iPFEZk08Tw==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.15.0.tgz",
+      "integrity": "sha512-Aj7TbFdAIWZdkX8JfdDStERpR35g6WNs+7XhNPtFLFOizUotj6k4N/D8HJkR45165HhnMJBe4hjOeeaxnnn56Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app-check-interop-types": "0.3.4",
-        "@firebase/component": "0.7.3",
-        "@firebase/logger": "0.5.1",
-        "@firebase/util": "1.15.1",
+        "@firebase/app-check-interop-types": "0.3.5",
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1908,15 +1914,15 @@
       }
     },
     "node_modules/@firebase/analytics": {
-      "version": "0.10.22",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.22.tgz",
-      "integrity": "sha512-8BSaq/QRGU1+xyi8L2PTLTJU7MH9aMA72RQdIxrbhWFauOZY9OXo8f2YDN/972xA8d588tlnNVEQ2Mo69pT9Ow==",
+      "version": "0.10.24",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.24.tgz",
+      "integrity": "sha512-OfIAcIIwoqXjBzS+DnUQpOZ7i3ePaNFg83KPpDWjBZUKJmqMwzzAtLJqmKZOkQnW8im6vFR6f2I3M/9hxVd+QA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.3",
-        "@firebase/installations": "0.6.22",
-        "@firebase/logger": "0.5.1",
-        "@firebase/util": "1.15.1",
+        "@firebase/component": "0.7.5",
+        "@firebase/installations": "0.6.24",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -1924,36 +1930,37 @@
       }
     },
     "node_modules/@firebase/analytics-compat": {
-      "version": "0.2.28",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.28.tgz",
-      "integrity": "sha512-lIAlqUUbBu93FJMlQfslryQtBwwzdzvp23ePC6FNgymXk6Ook5v4Uvc0vdutvoIeqmyA3LfP0ZeRFK8+11kOOQ==",
+      "version": "0.2.30",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.30.tgz",
+      "integrity": "sha512-uVZEKlLaW4AHAhv8zoN9cTmveX6v86AVqcJ4LCaRCMTChTH8/NsjbisTq1lpBfWCLWS1spqwSHB4vol/YSCdMA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/analytics": "0.10.22",
-        "@firebase/analytics-types": "0.8.4",
-        "@firebase/component": "0.7.3",
-        "@firebase/util": "1.15.1",
+        "@firebase/analytics": "0.10.24",
+        "@firebase/analytics-types": "0.8.5",
+        "@firebase/component": "0.7.5",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
+        "@firebase/app": "0.x",
         "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/analytics-types": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.4.tgz",
-      "integrity": "sha512-zQ+XTgkwH6CY/eUSHJRP7e4LxM30RCxlCmob5sy2axs25GE3Ny0XdgpDscMTHHQIGqWkxPXad4w2Mw9sCgT8zQ==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.5.tgz",
+      "integrity": "sha512-kdnooE7Bis2jEnsqcerRwn/UQpH5D3uvHpku7OdUM9TJN3omlu6iYtbyAQ6XkAJRgJtO0aNf9OOkW8J6D59oCA==",
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/app": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.15.1.tgz",
-      "integrity": "sha512-iD9+Z5HcPo0Uop5f72/VYMeXwKucBhW7iFrISkJFvQ+lSZikTNgTz0FgAtaaTkAG0pEZSnCymA2Fu49n0rcufQ==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.16.1.tgz",
+      "integrity": "sha512-tjUEorFyKrurH7PbLWv9zDHRuU4mLefgD/yY38D584ziorIRlQz/PVjx4c/SCGyCuUlmyzt72mK+Lh+COAywNQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.3",
-        "@firebase/logger": "0.5.1",
-        "@firebase/util": "1.15.1",
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
         "idb": "7.1.1",
         "tslib": "^2.1.0"
       },
@@ -1962,14 +1969,14 @@
       }
     },
     "node_modules/@firebase/app-check": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.12.0.tgz",
-      "integrity": "sha512-wMeT6HLWRAuW7Cp/5UjWBGKgjPNxWNOoNf4PRIv0weljoGMZVeqbUY7wNBWTI2/31cX1NlXx8gQruDLsUShB3Q==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.13.1.tgz",
+      "integrity": "sha512-l8y3dmnhodXks/APAwx4tWqRl3tk8b9874KF1FJyKg1DIU+kMD0l52iz7S9/MW+eK8k6cjJg0G0iJ5KQAsQpow==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.3",
-        "@firebase/logger": "0.5.1",
-        "@firebase/util": "1.15.1",
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1980,47 +1987,48 @@
       }
     },
     "node_modules/@firebase/app-check-compat": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.4.5.tgz",
-      "integrity": "sha512-JI17mVcZs34zO6ZeSCrw4U2iohqy+n6GIzkbmsA+TbVjmvFLkUKt3bs5M+qRBteQm/0IWzqSHYFzEQLzDTQebg==",
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.4.7.tgz",
+      "integrity": "sha512-fBb/xSMyIKv1nDmccfzz3IAGBzx/cQOxmZai66rJzifb1hMMkztf824Xx7LhpTUe7HNUbXwY90IvJ66fi8q6yg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app-check": "0.12.0",
-        "@firebase/app-check-types": "0.5.4",
-        "@firebase/component": "0.7.3",
-        "@firebase/logger": "0.5.1",
-        "@firebase/util": "1.15.1",
+        "@firebase/app-check": "0.13.1",
+        "@firebase/app-check-types": "0.5.5",
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
+        "@firebase/app": "0.x",
         "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/app-check-interop-types": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.4.tgz",
-      "integrity": "sha512-zz3i6e13B8BfWiLy8MABtTh8aGIACgKbf9UVnyHcWs+yQzJXgQcl8A46b0zfaiJHdQ+niF0ouAfcpuf+3LMPQg==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.5.tgz",
+      "integrity": "sha512-qId34pVZ2CXTmtu4ofW5leiI93DvnOvIcr/5GT7MZPw5WXAi6nZoU+g9cNRgl7K90UJSbK0cXxten4meYMPyZg==",
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/app-check-types": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.4.tgz",
-      "integrity": "sha512-xV7JsIyzVr15aA7f3Pi0rB9gdBuVubs89FGA8VkRYA4g0l78poADgdfrScgf7NndSg9mm7cR7PJyY0+t22KaGw==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.5.tgz",
+      "integrity": "sha512-+DF4gzFrlwGFyky38o4T/YN/r51l70yCtJ2HTkwmRj8FCMwPjm4hLH4fQbj6BUvzkiFqliBkitFsRpf1/YZkWA==",
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/app-compat": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.15.tgz",
-      "integrity": "sha512-HaiSM9TwbGIR4b7F6+UncHWlqdH89eeY7VUskaOGOlI2PxHS5Z+6hHsYGvNLy0SHDE6zyXO+3QSA6a4aqQxsqA==",
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.17.tgz",
+      "integrity": "sha512-5GdJWobqs6jbNYOnaQiSa4Ng8gnFerhqr7nY+v5jlnT7o9QbEeIZRLPQpnLe0TxYSWfRV2lAMbyR0kbXeIos9Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app": "0.15.1",
-        "@firebase/component": "0.7.3",
-        "@firebase/logger": "0.5.1",
-        "@firebase/util": "1.15.1",
+        "@firebase/app": "0.16.1",
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -2028,23 +2036,23 @@
       }
     },
     "node_modules/@firebase/app-types": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.5.tgz",
-      "integrity": "sha512-YevqTjvo7Iujsa9Dwowmd6dSoElhzmD63ZSrq6bzjvQ6POjYgNjOFHLmNIgJs48eNO093NCERibuFnxbfOvU7A==",
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.6.tgz",
+      "integrity": "sha512-yPLahy7Esfu2w/yme3msVK4xTkDXQqq6szfQn8yVOQpCKiT5GVFjqNpLbuz6NkX0WuTwUidkmPewW3r4xkvpeg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/logger": "0.5.1"
+        "@firebase/logger": "0.5.2"
       }
     },
     "node_modules/@firebase/auth": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.13.3.tgz",
-      "integrity": "sha512-bqiq4uubDN2YyQkdvSWPQeJyXAv2O76ImF41En9b6UhV5JuBVYDoHYrrrE3NzIuGkpFMKagfhMRP4Vz6t+yQSQ==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.13.5.tgz",
+      "integrity": "sha512-1AXoBJqBVD8WL8FZYo3S2GmJF9YUoom6Y6ngMxOSkzzhW5sT83pLchb6TGFgxes91dfXx8s/VYc5VrLDNqpLog==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.3",
-        "@firebase/logger": "0.5.1",
-        "@firebase/util": "1.15.1",
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -2061,34 +2069,35 @@
       }
     },
     "node_modules/@firebase/auth-compat": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.8.tgz",
-      "integrity": "sha512-llcBREUC4iSNKZ6rvwud7Oz9Q7aAWU6KuQLa6pdu7Q+QAQsy4JLw6yFgxwtmzabsgznHmmcsX2UjHLLzqUxi3Q==",
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.10.tgz",
+      "integrity": "sha512-Bvklg2nL7BrBFCAqdsleW8fse9Jh0fARqJPlJmA40uermfWx1bJiO7dnKyZN3J39d2TFVd4VJXtg3i6Wg92/YQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/auth": "1.13.3",
-        "@firebase/auth-types": "0.13.1",
-        "@firebase/component": "0.7.3",
-        "@firebase/util": "1.15.1",
+        "@firebase/auth": "1.13.5",
+        "@firebase/auth-types": "0.13.2",
+        "@firebase/component": "0.7.5",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
+        "@firebase/app": "0.x",
         "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/auth-interop-types": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.5.tgz",
-      "integrity": "sha512-1Li/YuBDBAXcKv7BzY4U28gontUmAaw53sYiqbaVOMCFb2lFKK/c3CGMUWqtwe7+TXrl3poWnTCL5umYBg85Eg==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.6.tgz",
+      "integrity": "sha512-FgwZqDrBqgK0BHI70QTv1v/5wmuDF9f8fsJFvKSxoRlK2PPfSQtZAk2jhXu4pe9BZzFi/e4UYusU/bEQHdf6Qg==",
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/auth-types": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.13.1.tgz",
-      "integrity": "sha512-0c1Mnid0uMDfGJHeUS4zfvBa4/CedJXotGy/n/NZJnBjwiJawt0ZYU+wH2VAVLiRCEfG2ncCkAX3yd1/2nrB7g==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.13.2.tgz",
+      "integrity": "sha512-OU+miuoSxIWYN7GT291d2ylVJBL3k/OePo7/JDSoQtkFQoEiGBc4AHuMjj/seqFIsHrqnjrAfRCk4pfufoJolQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@firebase/app-types": "0.x",
@@ -2096,12 +2105,12 @@
       }
     },
     "node_modules/@firebase/component": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.3.tgz",
-      "integrity": "sha512-wFofIaa2879ogD/WvkjYXJxRmfnL0scen6ORgaC3na1FNOR9ASIUANQdhqQcmWu/h77/pVHY7ch5flewa5Bcew==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.5.tgz",
+      "integrity": "sha512-vuFDcL91Q+2ZuBJkyOh86T4q0B4ffNTDjc/A38tybO56odQABxRTFLTIowCWqAKeIcgo37GowWMVgFF73gD8Qw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/util": "1.15.1",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -2109,15 +2118,15 @@
       }
     },
     "node_modules/@firebase/data-connect": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.7.1.tgz",
-      "integrity": "sha512-2LbUU8mmSA63HknxQMmWHjpzuNLBKflvVwQc2tpoVKg0biWleNEJX031ELks0vzFs+dDjOUkCJR72RP6mQHFOg==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.7.4.tgz",
+      "integrity": "sha512-su1aGWlzhxb+xtggCUSsufJn1FDa06SBDK71y+fpQ+g2zMhMExik6FUv/odkKzOF/xfWVjabCbWBcjJY3MceDA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/auth-interop-types": "0.2.5",
-        "@firebase/component": "0.7.3",
-        "@firebase/logger": "0.5.1",
-        "@firebase/util": "1.15.1",
+        "@firebase/auth-interop-types": "0.2.6",
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -2125,16 +2134,16 @@
       }
     },
     "node_modules/@firebase/database": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.3.tgz",
-      "integrity": "sha512-XwWCa+E4TvNGpGwXrycLRNfdogADwFcvuhyow6wDWma9W54roaQIhe+4PM0KiLsIftBdSCGI7OKCXrdSRHbIhw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.5.tgz",
+      "integrity": "sha512-/JGpvszLoNXNgzilRXocigGfFF4hbcPA9wN1i1kjJx6oKkXgkHteZYl3lQs1lJX3ETDf6bv7zI15lPMVUp4sAQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app-check-interop-types": "0.3.4",
-        "@firebase/auth-interop-types": "0.2.5",
-        "@firebase/component": "0.7.3",
-        "@firebase/logger": "0.5.1",
-        "@firebase/util": "1.15.1",
+        "@firebase/app-check-interop-types": "0.3.5",
+        "@firebase/auth-interop-types": "0.2.6",
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
         "faye-websocket": "0.11.4",
         "tslib": "^2.1.0"
       },
@@ -2143,45 +2152,57 @@
       }
     },
     "node_modules/@firebase/database-compat": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.4.tgz",
-      "integrity": "sha512-3pK35F1MAgmqFJQlf2nhQl44vtAXQO1uaCaQOEUI9kCRtLFqi7N+QRKR7lFZPg+xIZIyubgxQaxY69YgfZRZWg==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.7.tgz",
+      "integrity": "sha512-lBq9sJm8MnJINKJnkAKSOj2MbC66xGoSVCcGkPtstl+lkoKEBtD46qHLbuDgW/WbLPoKVm17RIN8BxHj+Z2F2w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.3",
-        "@firebase/database": "1.1.3",
-        "@firebase/database-types": "1.0.20",
-        "@firebase/logger": "0.5.1",
-        "@firebase/util": "1.15.1",
+        "@firebase/component": "0.7.5",
+        "@firebase/database": "1.1.5",
+        "@firebase/database-types": "1.0.22",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "engines": {
         "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-compat": "0.x"
+      },
+      "peerDependenciesMeta": {
+        "@firebase/app": {
+          "optional": true
+        },
+        "@firebase/app-compat": {
+          "optional": true
+        }
       }
     },
     "node_modules/@firebase/database-types": {
-      "version": "1.0.20",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.20.tgz",
-      "integrity": "sha512-kegbOk/w8iU64pr0q6k2ItyNGjnQBMHFhwS7ohdWI4W+pc0/zhhdGXTdFj6X1oxItRjPoYOsSQmERgBkn/ihxw==",
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.22.tgz",
+      "integrity": "sha512-YAZNXsjY9EQQ+pKw/3ax8n5FgolHC7Qew7EY5RceYdl0R2ZP+kCv1O0DkKlcceue8uQCOreHCNN7PWVFpY1Nug==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app-types": "0.9.5",
-        "@firebase/util": "1.15.1"
+        "@firebase/app-types": "0.9.6",
+        "@firebase/util": "1.15.3"
       }
     },
     "node_modules/@firebase/firestore": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.16.0.tgz",
-      "integrity": "sha512-qdHMHMvMr0nRMuZyWNR/ArWa0YlPE3C4eAbmxTASJMYXAesKPL0Y54p70moggrNPzaK7MSIIq5RDJJyntQyIYA==",
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.17.1.tgz",
+      "integrity": "sha512-8lqPNf2w10CtYG+tayVjZO1pSyQpnhztQRudeD109VtXDzNbASTaYdO43sj5PMsDcWq0aOYY3RmJOUlXu9++jw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.3",
-        "@firebase/logger": "0.5.1",
-        "@firebase/util": "1.15.1",
-        "@firebase/webchannel-wrapper": "1.0.6",
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
+        "@firebase/webchannel-wrapper": "1.0.7",
         "@grpc/grpc-js": "~1.9.0",
         "@grpc/proto-loader": "^0.7.8",
-        "re2js": "^0.4.2",
+        "re2js": "^2.8.3",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -2192,28 +2213,29 @@
       }
     },
     "node_modules/@firebase/firestore-compat": {
-      "version": "0.4.11",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.11.tgz",
-      "integrity": "sha512-W7o1WdwWq5aABK5Up2ncSvTQs/QGLR/fy7cVpFBNqhsXtxoMtflHf2xBIG6+aoptcuGAobddq4g2Sq27wqHaYw==",
+      "version": "0.4.13",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.13.tgz",
+      "integrity": "sha512-l9dCewxMzzLOIhcwTjERCKxrWOn1kZ9JvwOQq9zZNq4I/Nbvb/B9njT230V61uvQ9qZ3/qpUG758D8DDTEFXnw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.3",
-        "@firebase/firestore": "4.16.0",
-        "@firebase/firestore-types": "3.0.4",
-        "@firebase/util": "1.15.1",
+        "@firebase/component": "0.7.5",
+        "@firebase/firestore": "4.17.1",
+        "@firebase/firestore-types": "3.0.5",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
+        "@firebase/app": "0.x",
         "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/firestore-types": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.4.tgz",
-      "integrity": "sha512-jGn+JSS4X9zZsrfu7Yw66v5YRdOLD1oyQh4USR0xWl4CUqV/DA6bNIXRPpxH/cUl3iVTNiP6MN7g+EL42A4qfA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.5.tgz",
+      "integrity": "sha512-dbdMAQkMd5dwWc48eupz/Y6/E9ruat3+gY5lhVKscvvT/HnDBEEMzJW38zdKhgdnglZHGk2vUsJMOHAphMHGMA==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@firebase/app-types": "0.x",
@@ -2221,16 +2243,16 @@
       }
     },
     "node_modules/@firebase/functions": {
-      "version": "0.13.5",
-      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.13.5.tgz",
-      "integrity": "sha512-bWCx713f4kE/uFV7gdFOLBS7lDoiZj48MRkbAqe35gkXcCeWF4QjRNO07Jhmve7EJIoQOBczL29y2r8VRuN1kw==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.14.0.tgz",
+      "integrity": "sha512-DhuYFr0eMhp+s/PNEk6SiMsYkc00+XVOUeKbrl8MOzQNZI3SKQpqoDR1d+keNDAutwmHRWTUAdXBoVPD+xxVUw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app-check-interop-types": "0.3.4",
-        "@firebase/auth-interop-types": "0.2.5",
-        "@firebase/component": "0.7.3",
-        "@firebase/messaging-interop-types": "0.2.5",
-        "@firebase/util": "1.15.1",
+        "@firebase/app-check-interop-types": "0.3.5",
+        "@firebase/auth-interop-types": "0.2.6",
+        "@firebase/component": "0.7.5",
+        "@firebase/messaging-interop-types": "0.2.6",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -2241,38 +2263,39 @@
       }
     },
     "node_modules/@firebase/functions-compat": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.4.5.tgz",
-      "integrity": "sha512-10qlUXGY25G5/1g9UihqksPp2po+ZqSE7LEizsrdUP7vrTmkysXxGSZCDyojSEp6mQe/ecRDdDDI+z4XRdb4wQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.5.0.tgz",
+      "integrity": "sha512-T3BDIToESZUHt7438wyKYMkRjKg3m1xAIux5fVpNvTRQlDOFLukWniQWBDhJ2znpU9kxMTR6+e31TVo8P15PZw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.3",
-        "@firebase/functions": "0.13.5",
-        "@firebase/functions-types": "0.6.4",
-        "@firebase/util": "1.15.1",
+        "@firebase/component": "0.7.5",
+        "@firebase/functions": "0.14.0",
+        "@firebase/functions-types": "0.6.5",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
+        "@firebase/app": "0.x",
         "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/functions-types": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.4.tgz",
-      "integrity": "sha512-zV6kgqtduR4rUAdC/ilS7kmb93XD7bEZoJDlVBZqlOw2uGGGCNBQBuleww2rr0Ulr3L9o2TDjumEt68/l1f9DQ==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.5.tgz",
+      "integrity": "sha512-Zc0pURjthHXzSj54ZivCkzKDSV1r/wIpnmHdhq82q2yFFPVoncG/ZJjnVMiANvQfeww/QnElhzODpfwUucVwdA==",
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/installations": {
-      "version": "0.6.22",
-      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.22.tgz",
-      "integrity": "sha512-ef6nn3GGQTdReCfotRMG77PJZu8CqEbiK5pEoBnM0gTu/Z9v0i/az2p3HABsa/1beQmmyh1OsOjf7P5+pgwdZw==",
+      "version": "0.6.24",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.24.tgz",
+      "integrity": "sha512-Ui52ey8wHoWqkBbXRKJEKYWylI0JZogZmoLS+o8Anh1bxWtK27ZYjLla1UJAAdC5DCKLJ2qAp0VpJOjg8VOX1g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.3",
-        "@firebase/util": "1.15.1",
+        "@firebase/component": "0.7.5",
+        "@firebase/util": "1.15.3",
         "idb": "7.1.1",
         "tslib": "^2.1.0"
       },
@@ -2281,34 +2304,35 @@
       }
     },
     "node_modules/@firebase/installations-compat": {
-      "version": "0.2.22",
-      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.22.tgz",
-      "integrity": "sha512-C/zpAuTP5S9OgKSPvXRupw3hoY/JZSlA1wFjD/Sb7LIQE0FNbcMdO8Y4KXVEkjVzma/DDDDIAzxEXqKMAzc88w==",
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.24.tgz",
+      "integrity": "sha512-8M5nlcWwYt881x83COP2odq5vgf+NgwJh+RMd4LRSv8JI1pxwDfgrDJOERrjTgfC9J5Z0vnQX4b1pdN914e0Zw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.3",
-        "@firebase/installations": "0.6.22",
-        "@firebase/installations-types": "0.5.4",
-        "@firebase/util": "1.15.1",
+        "@firebase/component": "0.7.5",
+        "@firebase/installations": "0.6.24",
+        "@firebase/installations-types": "0.5.5",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
+        "@firebase/app": "0.x",
         "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/installations-types": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.4.tgz",
-      "integrity": "sha512-U2eFapdHwjb43Vx9o+Pmj4dFfvcHEK1IirEFLqMtWrTHvmdrS3gBpBD1kmJk/9HjsOtoHZxJ2Paoe79e+L1ZPg==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.5.tgz",
+      "integrity": "sha512-e9UYcju3puDl1vdrcKIi5dExzHLameOT/Tc61Q48PYwxtsM1NzZh/ikGbdBQTsbRgg0EMZqdPr0/m5ODUBobrg==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@firebase/app-types": "0.x"
       }
     },
     "node_modules/@firebase/logger": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.1.tgz",
-      "integrity": "sha512-vZKLsqE1ABOy8OjQiE7cUTFn4gvaqlk88yp8N94Pk/sDpq61YqZGqmVFZTvOyflTwuYFcWirBdYGoJgbDaXKYQ==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.2.tgz",
+      "integrity": "sha512-J2VO4NFTc0xQFrxV1B/lm5balicm9cwuX2acR9Yn41fN8KgUeQFo+VJV222IqW2FPSXKDu9uo5WdQFWf9TPbYg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -2318,15 +2342,15 @@
       }
     },
     "node_modules/@firebase/messaging": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.13.0.tgz",
-      "integrity": "sha512-GZoo0uGRvEbszo83xcgbjJp4FpkmBEr4l8Z4hi8gl+P1Spn/MTK3HapanMzSX4yUHuTEiF5hasWRxOaz+o5sxQ==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.13.2.tgz",
+      "integrity": "sha512-KcZoqUu2ih4sLH91dW9tmyHjCR0IQyNzSLZunX5uq7cLeImXb4uO2I0wq5FACduO2I+FoTeWa2BtUv7Jpowqdw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.3",
-        "@firebase/installations": "0.6.22",
-        "@firebase/messaging-interop-types": "0.2.5",
-        "@firebase/util": "1.15.1",
+        "@firebase/component": "0.7.5",
+        "@firebase/installations": "0.6.24",
+        "@firebase/messaging-interop-types": "0.2.6",
+        "@firebase/util": "1.15.3",
         "idb": "7.1.1",
         "tslib": "^2.1.0"
       },
@@ -2335,36 +2359,37 @@
       }
     },
     "node_modules/@firebase/messaging-compat": {
-      "version": "0.2.27",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.27.tgz",
-      "integrity": "sha512-JNOiu1PPgdHzEPEtoFiNxQuu0x9bm4bfETSQCpGfcTlgWkhlSK7uh7nlsjC10TQLUNgYetLmuutaYTh8aeYLVA==",
+      "version": "0.2.29",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.29.tgz",
+      "integrity": "sha512-8Twe4CeYvAx8AzjBxyyQFKzinaMGGt13hPQBqaARQ2QZjagrEaqSVBe+Zy6F4L/vT8DV168yRgRu7W/RK7p+4w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.3",
-        "@firebase/messaging": "0.13.0",
-        "@firebase/util": "1.15.1",
+        "@firebase/component": "0.7.5",
+        "@firebase/messaging": "0.13.2",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
+        "@firebase/app": "0.x",
         "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/messaging-interop-types": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.5.tgz",
-      "integrity": "sha512-tUEKnaAP2Y/MNIqgnriPpV6e5l13Vs/+p2yrd6NGlncPJT9O3a8muYZtdnWe+IJ4fgKLHJVC79n/asxk/N5Msw==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.6.tgz",
+      "integrity": "sha512-MVzvkKe2V4H2dHu5oOxRfeKQcfTwWmCgnzsC4V1q3ixun5iiL8riCZ2qI35rDhCL4glPGiu0jHxDbpVNuTKfow==",
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/performance": {
-      "version": "0.7.12",
-      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.12.tgz",
-      "integrity": "sha512-fe7nV8teUU3OBHlMUZ9Lw4gLhCW2k4m5Uc3pfWGV+fl8uwJQBGp9Q3lqsJ+HSrFu3Q2pJyLAgrClPGSKyDeYgQ==",
+      "version": "0.7.14",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.14.tgz",
+      "integrity": "sha512-9PH1XEZVHErxGdbXluvGz4Uyjw4W955H8v7Mv9rHIybRrg5F2Ac2tvf5+mSf5EtnxWNmxrD2WLnvMFaZP4sMrQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.3",
-        "@firebase/installations": "0.6.22",
-        "@firebase/logger": "0.5.1",
-        "@firebase/util": "1.15.1",
+        "@firebase/component": "0.7.5",
+        "@firebase/installations": "0.6.24",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0",
         "web-vitals": "^4.2.4"
       },
@@ -2373,38 +2398,39 @@
       }
     },
     "node_modules/@firebase/performance-compat": {
-      "version": "0.2.25",
-      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.25.tgz",
-      "integrity": "sha512-q6NjTXpIPoFuUmCmMN/maCdTgzT6aExs9xZo+PxfVLj6uLVGvpyAD6XWjmcrb7jChsFBYbq7E5dyNDF7Zhy9kA==",
+      "version": "0.2.27",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.27.tgz",
+      "integrity": "sha512-O/ozTf/EbChN94Pk7bd1eUC0PAC36726AwsaiJyC0bZzSBWfLGSWASGPH5pebUWXQPJtGxIJYRkkbX5l0Qa+Hw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.3",
-        "@firebase/logger": "0.5.1",
-        "@firebase/performance": "0.7.12",
-        "@firebase/performance-types": "0.2.4",
-        "@firebase/util": "1.15.1",
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/performance": "0.7.14",
+        "@firebase/performance-types": "0.2.5",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
+        "@firebase/app": "0.x",
         "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/performance-types": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.4.tgz",
-      "integrity": "sha512-kJSEk7b0uhpcPRyL4SQ/GPujLqk52XNKcXlnsKDbWGAb9vugcLvOU3u6zfEdwd+d8hWJb5S5ZizV1JFFI0nkKg==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.5.tgz",
+      "integrity": "sha512-PRzOgB+/M+6AKlEkY8a9xy5Ff5SfZPIh4iShXhn2WAcL/euSbK7bdLqWysHduunNJhGFsXa22Ag3ixqL6rQtYg==",
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/remote-config": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.9.0.tgz",
-      "integrity": "sha512-aNn6/eJhsSC+gXSToiXiYPv3ypLP9lFtzl+/q9kSOBPB7D6rae0Rt2uENZZLXGYbEgHYKQblOhijJAXGbbJjtQ==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.9.2.tgz",
+      "integrity": "sha512-Rii93DkXjM+RE/ytHdYa7EIiQLJbdBr+W8EEiqd/vbLCOC+1FdkDuRiumJBp6t3yewHGbdqbpjB3fk3z0cZ+8g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.3",
-        "@firebase/installations": "0.6.22",
-        "@firebase/logger": "0.5.1",
-        "@firebase/util": "1.15.1",
+        "@firebase/component": "0.7.5",
+        "@firebase/installations": "0.6.24",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -2412,36 +2438,37 @@
       }
     },
     "node_modules/@firebase/remote-config-compat": {
-      "version": "0.2.27",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.27.tgz",
-      "integrity": "sha512-FYwYWwSbUdza/pRX4NpSBm/Pimntum3jEIBpnDn5Ey1jHNWgjxrE8Z5SB4mCHd5wGCoYd3koJzxARl/VWIEx0Q==",
+      "version": "0.2.29",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.29.tgz",
+      "integrity": "sha512-mY7JtTISK6F4g4T0x3kVepr5cp0NXL7f5yjIUXXGaTrg4qUlFBWRbENaHaqZ78dwmNcLm24h/yPsOVRlDXEXhA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.3",
-        "@firebase/logger": "0.5.1",
-        "@firebase/remote-config": "0.9.0",
-        "@firebase/remote-config-types": "0.5.1",
-        "@firebase/util": "1.15.1",
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/remote-config": "0.9.2",
+        "@firebase/remote-config-types": "0.5.2",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
+        "@firebase/app": "0.x",
         "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/remote-config-types": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.5.1.tgz",
-      "integrity": "sha512-cX/1LT6KQwkXzck2eSzeKnuvXZCyr8qaPpDcikoJs7jmI+oBOXixpDLeDtWj1U6GNMkIoXrEDNoyT2Ypcyp5/A==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.5.2.tgz",
+      "integrity": "sha512-i8k1omVfoAnaT1ZPv2FFjxMZrATYsO/GnFgHEj5+7fAJLzi8wLnGGv1WK06oEAD6ltrWXSO1HzeNyajn/NjMWw==",
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/storage": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.14.3.tgz",
-      "integrity": "sha512-YX4/YL6P6/fufSSeGnVhjWddcIXbFq2cWIhMKFTZo1E/Rtcl2mJj/BYUQTwJfcE1Tl8un1FOya4L05jcSLN/Eg==",
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.14.5.tgz",
+      "integrity": "sha512-r2tozN/BlEewLi70tJNUQPzWwbex9GM7NgXZsamHKQrjKEfcR0i4jGgHBKAKA4hbwiPE9eNMb3hcxWnDpeJZwg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.3",
-        "@firebase/util": "1.15.1",
+        "@firebase/component": "0.7.5",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -2452,28 +2479,29 @@
       }
     },
     "node_modules/@firebase/storage-compat": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.4.3.tgz",
-      "integrity": "sha512-gruVqjtUGX8tEoeNbaWXZm0Zfcfcb7fvmDmBxV8yPAbWvExRnZYLO2+qw9idxNE7BvPXt5csyjSYHy//dAizxw==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.4.5.tgz",
+      "integrity": "sha512-vO0tFPxXbKDKdlTu8tYT08S9t9ezUTJYEdLCULpWxWq2aq6zojwN1QmAB+1a50AI/g47GlWUJn1XPncm/PDZsw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.3",
-        "@firebase/storage": "0.14.3",
-        "@firebase/storage-types": "0.8.4",
-        "@firebase/util": "1.15.1",
+        "@firebase/component": "0.7.5",
+        "@firebase/storage": "0.14.5",
+        "@firebase/storage-types": "0.8.5",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
+        "@firebase/app": "0.x",
         "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/storage-types": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.4.tgz",
-      "integrity": "sha512-BT7cwxJOx8SWwlQfrlC+bD/Sk3Cw+1odCi8UZNFNWTVZoPsBnA5W+mqtZzVnvsdJpXCFGSGQ7R7vOR6dtM/BRA==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.5.tgz",
+      "integrity": "sha512-GEDs5P+rNUfNcS+wxIdOLAHficife2YXtvTJnyi3ssrX11AAtBg+nDUdbYh8vuBzWehVQZPmztGUUnud4L+4yg==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@firebase/app-types": "0.x",
@@ -2481,9 +2509,9 @@
       }
     },
     "node_modules/@firebase/util": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.15.1.tgz",
-      "integrity": "sha512-LUdM4Wg7YM9Pq/49nGYySJA0CSQEKnGffFzWV8+6gXN7mGxn+FL1IqvFbuZUtAQcfZgHYDwCE1wwlK7rB7gl2g==",
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.15.3.tgz",
+      "integrity": "sha512-c/z/gaIlaaLZEuGbE6sLUuJ61tskg1JghvhcNQzW948ASBinbVBBRnZTC4b4yt4LaEtJQkYlyzqLHcutFwEIvA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2494,9 +2522,9 @@
       }
     },
     "node_modules/@firebase/webchannel-wrapper": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.6.tgz",
-      "integrity": "sha512-Vr/Mqu79dMwGRAyGbJ4uN4+BtXB3/mRTdzetD1daWNeG8QaWuzhhbG77GltO5c0yYmYls8i250iX73624GJd7Q==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.7.tgz",
+      "integrity": "sha512-phBFwieDLvkZGYN9CE9ZFNEIoBVksprzsnCzQejCmCHtgwCXReeuRpoEGN9C4EbhONztv8NRV1tau6Rb9pONwQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@gar/promise-retry": {
@@ -10002,39 +10030,39 @@
       }
     },
     "node_modules/firebase": {
-      "version": "12.16.0",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.16.0.tgz",
-      "integrity": "sha512-CNw6hFBdONkzF8UGLDx/RDRY9gVa5VmJNHd7qi4gdmA3ZuLkuOrhmWefB2l+FN+OxFpN77Itq7aO6zlTi780ag==",
+      "version": "12.18.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.18.0.tgz",
+      "integrity": "sha512-XaL6tlE5Xd20ZDhckqOMIw+JJTET+wTdeZPxQ7ihc42oxRb7kWUyn/j1LO5V9dH1xq8Rv5R71Pv1fBCdIkt9Rw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/ai": "2.13.1",
-        "@firebase/analytics": "0.10.22",
-        "@firebase/analytics-compat": "0.2.28",
-        "@firebase/app": "0.15.1",
-        "@firebase/app-check": "0.12.0",
-        "@firebase/app-check-compat": "0.4.5",
-        "@firebase/app-compat": "0.5.15",
-        "@firebase/app-types": "0.9.5",
-        "@firebase/auth": "1.13.3",
-        "@firebase/auth-compat": "0.6.8",
-        "@firebase/data-connect": "0.7.1",
-        "@firebase/database": "1.1.3",
-        "@firebase/database-compat": "2.1.4",
-        "@firebase/firestore": "4.16.0",
-        "@firebase/firestore-compat": "0.4.11",
-        "@firebase/functions": "0.13.5",
-        "@firebase/functions-compat": "0.4.5",
-        "@firebase/installations": "0.6.22",
-        "@firebase/installations-compat": "0.2.22",
-        "@firebase/messaging": "0.13.0",
-        "@firebase/messaging-compat": "0.2.27",
-        "@firebase/performance": "0.7.12",
-        "@firebase/performance-compat": "0.2.25",
-        "@firebase/remote-config": "0.9.0",
-        "@firebase/remote-config-compat": "0.2.27",
-        "@firebase/storage": "0.14.3",
-        "@firebase/storage-compat": "0.4.3",
-        "@firebase/util": "1.15.1"
+        "@firebase/ai": "2.15.0",
+        "@firebase/analytics": "0.10.24",
+        "@firebase/analytics-compat": "0.2.30",
+        "@firebase/app": "0.16.1",
+        "@firebase/app-check": "0.13.1",
+        "@firebase/app-check-compat": "0.4.7",
+        "@firebase/app-compat": "0.5.17",
+        "@firebase/app-types": "0.9.6",
+        "@firebase/auth": "1.13.5",
+        "@firebase/auth-compat": "0.6.10",
+        "@firebase/data-connect": "0.7.4",
+        "@firebase/database": "1.1.5",
+        "@firebase/database-compat": "2.1.7",
+        "@firebase/firestore": "4.17.1",
+        "@firebase/firestore-compat": "0.4.13",
+        "@firebase/functions": "0.14.0",
+        "@firebase/functions-compat": "0.5.0",
+        "@firebase/installations": "0.6.24",
+        "@firebase/installations-compat": "0.2.24",
+        "@firebase/messaging": "0.13.2",
+        "@firebase/messaging-compat": "0.2.29",
+        "@firebase/performance": "0.7.14",
+        "@firebase/performance-compat": "0.2.27",
+        "@firebase/remote-config": "0.9.2",
+        "@firebase/remote-config-compat": "0.2.29",
+        "@firebase/storage": "0.14.5",
+        "@firebase/storage-compat": "0.4.5",
+        "@firebase/util": "1.15.3"
       }
     },
     "node_modules/firebase-admin": {
@@ -15685,10 +15713,13 @@
       }
     },
     "node_modules/re2js": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/re2js/-/re2js-0.4.3.tgz",
-      "integrity": "sha512-EuNmh7jurhHEE8Ge/lBo9JuMLb3qf866Xjjfyovw3wPc7+hlqDkZq4LwhrCQMEI+ARWfrKrHozEndzlpNT0WDg==",
-      "license": "MIT"
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/re2js/-/re2js-2.8.6.tgz",
+      "integrity": "sha512-xLgQil4kIUCrAzVk9fRSkxkFNwmygLFjVxXrLc65aE1F0+Zsb8rxumFBy4XKyvgMCTL6kilDq3EZ0piE2dP/Dg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",
@@ -17370,7 +17401,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/sample/package.json
+++ b/sample/package.json
@@ -22,7 +22,7 @@
     "@angular/ssr": "^21.0.0",
     "cookie-parser": "^1.4.7",
     "express": "^5.1.0",
-    "firebase": "^12.4.0",
+    "firebase": "^12.18.0",
     "firebase-admin": "^13.0.1",
     "js-cookie": "^3.0.5",
     "rxjs": "~7.8.0",

--- a/src/messaging/firebase.ts
+++ b/src/messaging/firebase.ts
@@ -6,7 +6,11 @@ import {
   getMessaging as _getMessaging,
   getToken as _getToken,
   isSupported as _isSupported,
-  onMessage as _onMessage
+  onMessage as _onMessage,
+  onRegistered as _onRegistered,
+  onUnregistered as _onUnregistered,
+  register as _register,
+  unregister as _unregister
 } from 'firebase/messaging';
 
 export const deleteToken = ɵzoneWrap(_deleteToken, true, 2);
@@ -14,3 +18,7 @@ export const getMessaging = ɵzoneWrap(_getMessaging, true);
 export const getToken = ɵzoneWrap(_getToken, true);
 export const isSupported = ɵzoneWrap(_isSupported, false);
 export const onMessage = ɵzoneWrap(_onMessage, false);
+export const onRegistered = ɵzoneWrap(_onRegistered, false);
+export const onUnregistered = ɵzoneWrap(_onUnregistered, false);
+export const register = ɵzoneWrap(_register, true);
+export const unregister = ɵzoneWrap(_unregister, true, 2);

--- a/src/package.json
+++ b/src/package.json
@@ -41,7 +41,7 @@
     "typescript": { "optional": true }
   },
   "dependencies": {
-    "firebase": "^12.4.0",
+    "firebase": "^12.18.0",
     "rxfire": "^6.2.0",
     "@angular-devkit/architect": ">= 0.2100.0 < 0.2200.0",
     "@angular-devkit/core": "^21.0.0",

--- a/src/schematics/common.jasmine.ts
+++ b/src/schematics/common.jasmine.ts
@@ -1,10 +1,18 @@
 import { readFileSync } from 'fs';
 import { logging } from '@angular-devkit/core';
 import { HostTree, SchematicContext } from '@angular-devkit/schematics';
+import { minVersion as semverMinVersion } from 'semver';
 import { alignFirebaseVersion, firebaseVersionRange, pinInstalledPrereleaseVersion } from './common.js';
 import 'jasmine';
 
 const context = { logger: new logging.Logger('test') } as unknown as SchematicContext;
+
+// The version a workspace already declares, written into the test package.json below.
+const lowestRequiredVersion = semverMinVersion(firebaseVersionRange);
+if (!lowestRequiredVersion) {
+  throw new Error(`firebaseVersionRange ${firebaseVersionRange} matches no version`);
+}
+const alreadySupportedRange = `~${lowestRequiredVersion.version}`;
 
 const treeWithAngularFire = (declaredVersion: string, section = 'dependencies') => {
   const tree = new HostTree();
@@ -12,7 +20,7 @@ const treeWithAngularFire = (declaredVersion: string, section = 'dependencies') 
     name: 'test-app',
     [section]: {
       '@angular/fire': declaredVersion,
-      firebase: '^12.4.0',
+      firebase: firebaseVersionRange,
     },
   }, null, 2));
   return tree;
@@ -40,7 +48,7 @@ describe('pinInstalledPrereleaseVersion', () => {
   it('leaves other dependencies untouched when pinning', () => {
     const tree = treeWithAngularFire('^21.0.0-rc.0');
     pinInstalledPrereleaseVersion(tree, context, '21.0.0-rc.0');
-    expect(dependenciesIn(tree).firebase).toBe('^12.4.0');
+    expect(dependenciesIn(tree).firebase).toBe(firebaseVersionRange);
   });
 
   it('leaves a stable caret range untouched', () => {
@@ -148,9 +156,9 @@ describe('alignFirebaseVersion', () => {
   });
 
   it('leaves a compatible range untouched', () => {
-    const tree = treeWithFirebase('^12.6.0');
+    const tree = treeWithFirebase(alreadySupportedRange);
     expect(alignFirebaseVersion(tree, context)).toBeFalse();
-    expect(dependenciesIn(tree).firebase).toBe('^12.6.0');
+    expect(dependenciesIn(tree).firebase).toBe(alreadySupportedRange);
   });
 
   it('adds firebase when the workspace has none', () => {
@@ -198,11 +206,11 @@ describe('alignFirebaseVersion', () => {
     const tree = new HostTree();
     tree.create('package.json', JSON.stringify({
       name: 'test-app',
-      dependencies: { firebase: '^12.6.0' },
+      dependencies: { firebase: alreadySupportedRange },
       devDependencies: { firebase: '^11.0.0' },
     }, null, 2));
     expect(alignFirebaseVersion(tree, context)).toBeTrue();
-    expect(dependenciesIn(tree).firebase).toBe('^12.6.0');
+    expect(dependenciesIn(tree).firebase).toBe(alreadySupportedRange);
     expect(sectionIn(tree, 'devDependencies').firebase).toBe(firebaseVersionRange);
   });
 

--- a/src/schematics/common.ts
+++ b/src/schematics/common.ts
@@ -72,10 +72,10 @@ export const addDependencies = (
   overwriteIfExists(host, 'package.json', stringifyFormatted(packageJson));
 };
 
-// Must stay identical to `dependencies.firebase` in `src/package.json`: if the two drift, the
-// alignment below can pin workspaces outside the range the library actually installs against,
-// re-creating the duplicate-SDK trees it exists to prevent.
-export const firebaseVersionRange = '^12.4.0';
+/* Must stay identical to `dependencies.firebase` in `src/package.json`: if the two drift, the
+ * alignment below can pin workspaces outside the range the library actually installs against,
+ * re-creating duplicate-SDK trees. */
+export const firebaseVersionRange = '^12.18.0';
 
 /**
  * Aligns the workspace's `firebase` entry with the range `@angular/fire` requires.

--- a/tools/build.ts
+++ b/tools/build.ts
@@ -66,8 +66,9 @@ const firestoreOverrides = {
 };
 
 /* Override keys the installed firebase's type declarations do not carry, which the generator
- * would otherwise read as typos. Keyed by entry point, so a name allowed for one module is not
- * allowed for the rest. At a version bump, drop a name from here but KEEP its override entry. */
+ * would otherwise read as typos. Keyed by entry point, but two entry points sharing one overrides
+ * object share these names too, the way firestore and firestore/lite share firestoreOverrides.
+ * At a version bump, drop a name from here but KEEP its override entry. */
 const overridesFirebaseDoesNotDeclare: Record<string, string[]> = {};
 
 type Overrides = Record<string, OverrideOptions | null>;

--- a/tools/build.ts
+++ b/tools/build.ts
@@ -65,19 +65,10 @@ const firestoreOverrides = {
   writeBatch: { logLevel: LogLevel.VERBOSE },
 };
 
-/* Override keys firebase's type declarations may not carry, which the generator would otherwise
- * read as typos. A name lands here because a later release adds it, firebase has removed it, or
- * firebase keeps it out of its public types on purpose (browserCookiePersistence). Listing a
- * declared name is harmless: getImagenModel is here for the version this build is heading to.
- * Keyed by entry point, so a name allowed for one module is not allowed for the rest.
- * At a version bump, drop a name from here but KEEP its override entry. */
-const overridesFirebaseDoesNotDeclare: Record<string, string[]> = {
-  'firebase/ai': ['getImagenModel', 'getTemplateGenerativeModel'],
-  'firebase/auth': ['browserCookiePersistence'],
-  'firebase/data-connect': ['makeMemoryCacheProvider'],
-  'firebase/firestore': ['maximum', 'minimum'],
-  'firebase/messaging': ['onRegistered', 'onUnregistered', 'unregister'],
-};
+/* Override keys the installed firebase's type declarations do not carry, which the generator
+ * would otherwise read as typos. Keyed by entry point, so a name allowed for one module is not
+ * allowed for the rest. At a version bump, drop a name from here but KEEP its override entry. */
+const overridesFirebaseDoesNotDeclare: Record<string, string[]> = {};
 
 type Overrides = Record<string, OverrideOptions | null>;
 
@@ -157,8 +148,6 @@ ${exportedZoneWrappedFns}
     reexport('ai', 'firebase', 'firebase/ai', tsKeys<typeof import('firebase/ai')>(), {
       // Unwrapped via the star export: no callback, returns the model object directly.
       getTemplateGenerativeModel: null,
-      // Removed in @firebase/ai 2.15.0 (firebase 12.18.0).
-      getImagenModel: null,
     }),
     reexport('analytics', 'firebase', 'firebase/analytics', tsKeys<typeof import('firebase/analytics')>(), {
       isSupported: { blockUntilFirst: false },


### PR DESCRIPTION
### Checklist

   - Issue number for this PR: #3756 (required)
   - Docs included?: yes (`docs/version-21-upgrade.md`, `docs/messaging.md`)
   - Test units included?: no new ones, two existing ones rewritten, see Testing below
   - In a clean directory, `yarn install`, `yarn test` run successfully? yes, via the npm equivalents

### Description

`tools/build.ts` writes `src/<module>/firebase.ts` from the type declarations of whatever `firebase` is installed, so which functions `@angular/fire` wraps is decided by the version the build resolves rather than by a list anyone maintains. This raises that version, and regenerates. #3756 has the background.

Three things follow from the way the generator works:

- The version the build resolves has been 12.4.0 while npm `latest` reached 12.18.0.
- Everything Firebase added in between still reaches callers through the `export *` line, but arrives with none of the wrapper's behavior and nothing saying it is different.
- The range the repository builds against, the range the published package declares and the schematics constant all have to move together, or `alignFirebaseVersion` starts writing a range the library does not install against.

#### What regenerating changes

- `src/messaging/firebase.ts` is the only generated file that moves. It gains `onRegistered`, `onUnregistered`, `register` and `unregister`.
- Nothing else changes, because #3759 already classified every other symbol the raise makes visible.
- Those entries keep their symbols out of the generated files while the `export *` line continues to carry them to callers.

#### What comes out

- `getImagenModel` carried an override entry so the generator would not emit a named import for a symbol firebase deleted in 12.18.0 (#3749, fixed by #3750).
- At this version the generator cannot see the symbol at all, so the entry has nothing left to do and goes.
- That empties `overridesFirebaseDoesNotDeclare`, which stays in place as the list the next unclassified name goes into.

#### What this means for someone upgrading

- `@angular/fire` declares `firebase` as a regular dependency rather than a peer, so a workspace holding an older `firebase` that upgrades `@angular/fire` without running a schematic now resolves two copies instead of one, and the two reject each other's objects at runtime. Measured under Testing rather than assumed.
- `alignFirebaseVersion` rewrites the declared range for anyone who runs `ng add` or `ng update`, and it picks up the new range with no further change.
- #3754 covers telling the people who run neither.

#### Specs

- Two `alignFirebaseVersion` specs used `^12.6.0` to stand for a range a workspace declares that is already inside what the library requires.
- `^12.6.0` stops being inside that range at 12.18.0, so both specs would have started asserting the opposite of what they say.
- They now derive that value from `firebaseVersionRange`, so the next raise cannot leave them wrong.

#### Docs

- `docs/messaging.md` wrote the firebase version into two gstatic service worker URLs, which is only correct on the day it is written. It now uses a placeholder, matching `docs/compat/messaging/messaging.md`.
- `docs/version-21-upgrade.md` names the new range, and no longer implies that only a `firebase` 11 workspace ends up with two copies.

### Testing

    npm run build && npm run build:jasmine && npm run test:node

- 227 specs, 0 failures.
- `npx ng lint` passes.
- The karma suite passes against the emulators: 107 executed, 48 skipped, 0 failures.

Two results are worth stating separately, because neither is visible in the diff.

#### The override entries are doing the work, not the version

- Every symbol #3759 marked unwrapped is absent from every generated file.
- Each of those five is a live `function` in the installed firebase 12.18.0, so their absence is those entries working rather than the version simply not having them.
- `getImagenModel` is `undefined` there, which is why its entry could go.

#### The duplicate copy was measured, not assumed

A fresh `ng new` app, `firebase` set to 12.10.0, this build of `@angular/fire` installed, no schematic run:

```
├─┬ @angular/fire@21.0.0-rc.0
│ ├── firebase@12.18.0
│ └─┬ rxfire@6.2.0
│   └── firebase@12.10.0 deduped
└── firebase@12.10.0
```

The split runs through the library's own dependencies: `@angular/fire` gets 12.18.0 while `rxfire`, which `@angular/fire` depends on, gets the app's 12.10.0. The same app with no `firebase` of its own resolves a single 12.18.0 for everything.

One judgment call I would particularly like a second opinion on: `register` is wrapped with `blockUntilFirst` at its default, which means a call made before notification permission is granted holds the application unstable while the browser prompt is open. `getToken` has done the same for years, and setting `false` would drop zone and injection-context re-entry from the returned promise rather than just the pending task, so I left it alone. If you would rather that not ship, say so and I will take it out of this PR.

Fixes #3756
